### PR TITLE
Use the same capitalization for 'Registration IP' message

### DIFF
--- a/src/User/Model/User.php
+++ b/src/User/Model/User.php
@@ -116,7 +116,7 @@ class User extends ActiveRecord implements IdentityInterface
         return [
             'username' => Yii::t('usuario', 'Username'),
             'email' => Yii::t('usuario', 'Email'),
-            'registration_ip' => Yii::t('usuario', 'Registration ip'),
+            'registration_ip' => Yii::t('usuario', 'Registration IP'),
             'unconfirmed_email' => Yii::t('usuario', 'New email'),
             'password' => Yii::t('usuario', 'Password'),
             'created_at' => Yii::t('usuario', 'Registration time'),

--- a/src/User/Search/UserSearch.php
+++ b/src/User/Search/UserSearch.php
@@ -71,7 +71,7 @@ class UserSearch extends Model
             'username' => Yii::t('usuario', 'Username'),
             'email' => Yii::t('usuario', 'Email'),
             'created_at' => Yii::t('usuario', 'Registration time'),
-            'registration_ip' => Yii::t('usuario', 'Registration ip'),
+            'registration_ip' => Yii::t('usuario', 'Registration IP'),
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/

While translating I noticed there were two messages for the very same text, *Registration IP*, one with capitalized *IP* and one without. This patch makes a single message out of two
