### PR TITLE
Fix of timezone saving in Profile

### DIFF
--- a/src/User/Model/Profile.php
+++ b/src/User/Model/Profile.php
@@ -125,7 +125,7 @@ class Profile extends ActiveRecord
      */
     public function setTimeZone(DateTimeZone $timezone)
     {
-        $this->setAttribute('timezone', $timezone);
+        $this->setAttribute('timezone', $timezone->getName());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

When setting timezone manually, we need to save its name instead of an object.