### PR TITLE
Prefill username and email in the form on the Account page

### DIFF
--- a/src/User/Form/SettingsForm.php
+++ b/src/User/Form/SettingsForm.php
@@ -46,11 +46,15 @@ class SettingsForm extends Model
     protected $securityHelper;
 
     /** @var User */
-    protected $user;
+    protected $_user;
 
     public function __construct(SecurityHelper $securityHelper, array $config = [])
     {
         $this->securityHelper = $securityHelper;
+        $this->setAttributes([
+            'username' => $this->user->username,
+            'email'    => $this->user->unconfirmed_email ?: $this->user->email,
+        ], false);
         parent::__construct($config);
     }
 
@@ -106,11 +110,11 @@ class SettingsForm extends Model
      */
     public function getUser()
     {
-        if ($this->user == null) {
-            $this->user = Yii::$app->user->identity;
+        if ($this->_user == null) {
+            $this->_user = Yii::$app->user->identity;
         }
 
-        return $this->user;
+        return $this->_user;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

Prefills username and email fields in the form on the Settings/Account page.