### PR TITLE
Allow setting permissions as children to roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 1.0.10 - Work In Progress
-- Fix: Allow setting permissions as children to roles (kurounin)
+- Fix #42: Allow setting permissions as children to roles (kurounin)
 - Fix #37: Fix bower alias in test environment (tekord)
 - Enh #32: Added Italian Translation (maxxer)
 - Fix #30: Prefill username and email in SettingsForm (mattheobjornson)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 1.0.10 - Work In Progress
+- Fix: Allow setting permissions as children to roles
 - Fix #37: Fix bower alias in test environment (tekord)
 - Enh #32: Added Italian Translation (maxxer)
 - Fix #30: Prefill username and email in SettingsForm (mattheobjornson)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 1.0.10 - Work In Progress
-- Fix: Allow setting permissions as children to roles
+- Fix: Allow setting permissions as children to roles (kurounin)
 - Fix #37: Fix bower alias in test environment (tekord)
 - Enh #32: Added Italian Translation (maxxer)
 - Fix #30: Prefill username and email in SettingsForm (mattheobjornson)

--- a/src/User/Helper/AuthHelper.php
+++ b/src/User/Helper/AuthHelper.php
@@ -99,7 +99,8 @@ class AuthHelper
     public function getUnassignedItems(AbstractAuthItem $model)
     {
         $excludeItems = $model->item !== null ? [$model->item->name] : [];
-        $items = $this->getAuthManager()->getItems($model->getType(), $excludeItems);
+        $type = $model->getType() == Permission::TYPE_PERMISSION ?: null;
+        $items = $this->getAuthManager()->getItems($type, $excludeItems);
 
         return ArrayHelper::map(
             $items,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | A role should be able to have as children not only other roles, but permissions as well
