### PR TITLE
`last_login_at` fix

### DIFF
--- a/src/User/Controller/SecurityController.php
+++ b/src/User/Controller/SecurityController.php
@@ -15,6 +15,7 @@ use Da\User\Contracts\AuthClientInterface;
 use Da\User\Event\FormEvent;
 use Da\User\Event\UserEvent;
 use Da\User\Form\LoginForm;
+use Da\User\Model\User;
 use Da\User\Query\SocialNetworkAccountQuery;
 use Da\User\Service\SocialNetworkAccountConnectService;
 use Da\User\Service\SocialNetworkAuthenticateService;
@@ -124,7 +125,7 @@ class SecurityController extends Controller
         if ($form->load(Yii::$app->request->post())) {
             $this->trigger(FormEvent::EVENT_BEFORE_LOGIN, $event);
             if ($form->login()) {
-                Yii::$app->getUser()->identity->updateAttributes(['last_login_at' => time()]);
+                User::findOne(Yii::$app->getUser()->getId())->updateAttributes(['last_login_at' => time()]);
 
                 $this->trigger(FormEvent::EVENT_AFTER_LOGIN, $event);
 

--- a/src/User/Controller/SecurityController.php
+++ b/src/User/Controller/SecurityController.php
@@ -125,7 +125,7 @@ class SecurityController extends Controller
         if ($form->load(Yii::$app->request->post())) {
             $this->trigger(FormEvent::EVENT_BEFORE_LOGIN, $event);
             if ($form->login()) {
-                User::findOne(Yii::$app->getUser()->getId())->updateAttributes(['last_login_at' => time()]);
+                $form->getUser()->updateAttributes(['last_login_at' => time()]);
 
                 $this->trigger(FormEvent::EVENT_AFTER_LOGIN, $event);
 

--- a/src/User/Form/LoginForm.php
+++ b/src/User/Form/LoginForm.php
@@ -137,4 +137,12 @@ class LoginForm extends Model
 
         return false;
     }
+    
+    /*
+     * @return User
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
 }


### PR DESCRIPTION
Fixed updating of `last_login_at`. 
updateAttributes() doesn't work on the Identity class.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #39 
