### PR TITLE
FormEvent::EVENT_AFTER_LOGIN right after login

### DIFF
--- a/src/User/Controller/SecurityController.php
+++ b/src/User/Controller/SecurityController.php
@@ -125,9 +125,9 @@ class SecurityController extends Controller
         if ($form->load(Yii::$app->request->post())) {
             $this->trigger(FormEvent::EVENT_BEFORE_LOGIN, $event);
             if ($form->login()) {
-                $form->getUser()->updateAttributes(['last_login_at' => time()]);
-
                 $this->trigger(FormEvent::EVENT_AFTER_LOGIN, $event);
+                
+                $form->getUser()->updateAttributes(['last_login_at' => time()]);
 
                 return $this->goBack();
             }


### PR DESCRIPTION
Example scenario:
I want to force the user change his password after his first login. When I call `EVENT_AFTER_LOGIN` the user already has the `last_login_at` attribute set, so I never know if the user has logged in before. I think it makes sense to change those 2 lines.
