### PR TITLE
Allow parent-child relationship to permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.14 - Work in progress
 - Enh #65: Updated Romanian translation (mrbig00)
 - Enh #61: Updated Russian translation (faenir)
+- Enh #70: Allow permission-permission parent-child relationship
 
 ## 1.0.13 - August 12, 2017
 - Fix #49: Fix wrong call of method make() for set attributes (MKiselev)

--- a/src/User/Helper/AuthHelper.php
+++ b/src/User/Helper/AuthHelper.php
@@ -99,7 +99,7 @@ class AuthHelper
     public function getUnassignedItems(AbstractAuthItem $model)
     {
         $excludeItems = $model->item !== null ? [$model->item->name] : [];
-        $type = $model->getType() == Permission::TYPE_PERMISSION ?: null;
+        $type = $model->getType() == Permission::TYPE_PERMISSION ? Permission::TYPE_PERMISSION : null;
         $items = $this->getAuthManager()->getItems($type, $excludeItems);
 
         return ArrayHelper::map(


### PR DESCRIPTION
It's even in [the guide](http://www.yiiframework.com/doc-2.0/guide-security-authorization.html#rbac) <kbd>ctrl</kbd>+<kbd>f</kbd> `updateownpost`

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | wasn't launched
| Fixed issues  | afaik none
