### PR TITLE
Update AccessRuleFilter to evaluate roleParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 1.0.14 - Work in progress
+- Enh #81: Update `AccessRuleFilter` to evaluate `roleParams` (kartik-v)
 - Enh #56: Added two factor authentication (tonydspaniard)
 - Fix #63: Fix selectize version (tonydspaniard)
 - Enh #65: Updated Romanian translation (mrbig00)

--- a/src/User/Filter/AccessRuleFilter.php
+++ b/src/User/Filter/AccessRuleFilter.php
@@ -41,8 +41,13 @@ class AccessRuleFilter extends AccessRule
                 if (!$user->getIsGuest() && $identity->getIsAdmin()) {
                     return true;
                 }
-            } elseif ($user->can($role)) {
-                return true;
+            } else {
+                if (!isset($roleParams)) {
+                    $roleParams = $this->roleParams instanceof Closure ? call_user_func($this->roleParams, $this) : $this->roleParams;
+                }
+                if ($user->can($role, $roleParams)) {
+                    return true;
+                }
             }
         }
 

--- a/src/User/Filter/AccessRuleFilter.php
+++ b/src/User/Filter/AccessRuleFilter.php
@@ -11,6 +11,7 @@
 
 namespace Da\User\Filter;
 
+use Closure;
 use Da\User\Model\User;
 use yii\filters\AccessRule;
 


### PR DESCRIPTION
The `roleParams` was not being evaluated earlier and has been included.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes (tested on own module  - not via unit test)
| Fixed issues  | new enhancement
