### PR TITLE
External links should open in a new tab|window

### DIFF
--- a/src/User/resources/views/settings/profile.php
+++ b/src/User/resources/views/settings/profile.php
@@ -71,7 +71,8 @@ $timezoneHelper = $model->make(TimezoneHelper::class);
                     ->hint(
                         Html::a(
                             Yii::t('usuario', 'Change your avatar at Gravatar.com'),
-                            'http://gravatar.com'
+                            'http://gravatar.com',
+                            ['target' => '_blank']
                         )
                     ) ?>
 


### PR DESCRIPTION
The gravatar link makes user leave the page without saving changes. Opening in a new tab prevent this.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | ?
