### PR TITLE
Correct exception value returned in `MailEvent::getException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 1.1.1 - Work in progress
+- Bug #106: Correct exception value returned in `MailEvent::getException` (kartik-v)
 - Enh #99: Added German translation (jkmssoft)
 - Enh #100: Added pt-BR translation (gugoan)
 

--- a/src/User/Event/MailEvent.php
+++ b/src/User/Event/MailEvent.php
@@ -62,6 +62,6 @@ class MailEvent extends Event
 
     public function getException()
     {
-        return $this->mailService;
+        return $this->exception;
     }
 }


### PR DESCRIPTION
Fix the exception returned.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    |no
| Tests pass?   | yes
| Fixed issues  | #79, #88, #91