### PR TITLE
Fix user search returning no results in admin page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 1.1.2 - Work in progress
+- Bug #133: Fix user search returning no results in admin page (phiurs)
 - Bug #125: Fix validation in non-ajax requests (faenir)
 - Bug #122: Fix wrong email message for email address change (liviuk2)
 

--- a/src/User/Search/UserSearch.php
+++ b/src/User/Search/UserSearch.php
@@ -63,7 +63,7 @@ class UserSearch extends Model
     {
         return [
             'safeFields' => [['username', 'email', 'registration_ip', 'created_at', 'last_login_at'], 'safe'],
-            'createdDefault' => ['created_at', 'default', 'value' => null],
+            'createdDefault' => [['created_at', 'last_login_at'], 'default', 'value' => null],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no

Fix a bug in user admin page, where an empty list is returned when performing a search, unless a value is entered in *last_login_at* search field
