### PR TITLE
Allow + sign in username

### DIFF
--- a/src/User/Model/User.php
+++ b/src/User/Model/User.php
@@ -175,7 +175,7 @@ class User extends ActiveRecord implements IdentityInterface
         return [
             // username rules
             'usernameRequired' => ['username', 'required', 'on' => ['register', 'create', 'connect', 'update']],
-            'usernameMatch' => ['username', 'match', 'pattern' => '/^[-a-zA-Z0-9_\.@]+$/'],
+            'usernameMatch' => ['username', 'match', 'pattern' => '/^[-a-zA-Z0-9_\.@\+]+$/'],
             'usernameLength' => ['username', 'string', 'min' => 3, 'max' => 255],
             'usernameTrim' => ['username', 'trim'],
             'usernameUnique' => [


### PR DESCRIPTION
Small modification to allow the **+** sign into usernames. 

When using emails as username it may happen to have the plus sign in the user part [see wikipedia](https://en.wikipedia.org/wiki/Email_address#Subaddressing). 

I don't see any inconsistency in allowing it, if you don't have anything against... 


| Q             | A
| ------------- | ---
| Is bugfix?    |no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
