### PR TITLE
Bugfix for Model events UserEvent::EVENT_BEFORE_CREATE and UserEvent:…

### DIFF
--- a/src/User/Service/UserCreateService.php
+++ b/src/User/Service/UserCreateService.php
@@ -57,14 +57,15 @@ class UserCreateService implements ServiceInterface
                 ? $model->password
                 : $this->securityHelper->generatePassword(8);
 
-            $model->trigger(UserEvent::EVENT_BEFORE_CREATE);
+            $event = $this->make(UserEvent::class, [$model]);
+            $model->trigger(UserEvent::EVENT_BEFORE_CREATE, $event);
 
             if (!$model->save()) {
                 $transaction->rollBack();
                 return false;
             }
 
-            $model->trigger(UserEvent::EVENT_AFTER_CREATE);
+            $model->trigger(UserEvent::EVENT_AFTER_CREATE, $event);
             if (!$this->sendMail($model)) {
                 Yii::$app->session->setFlash(
                     'warning',


### PR DESCRIPTION
…:EVENT_AFTER_CREATE

Feed instance of Da\User\Event\UserEvent to resolve error in event handlers:

TypeError
Argument 1 passed to {closure}() must be an instance of Da\User\Event\UserEvent, instance of yii\base\Event given

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | Bugfix for Model events UserEvent::EVENT_BEFORE_CREATE and UserEvent::EVENT_AFTER_CREATE
