### PR TITLE
 Bugfix for Model events UserEvent::EVENT_BEFORE_CONFIRMATION and Use…

### DIFF
--- a/src/User/Service/UserConfirmationService.php
+++ b/src/User/Service/UserConfirmationService.php
@@ -26,9 +26,12 @@ class UserConfirmationService implements ServiceInterface
 
     public function run()
     {
-        $this->model->trigger(UserEvent::EVENT_BEFORE_CONFIRMATION);
+        $model = $this->model;
+        $event = $this->make(UserEvent::class, [$model]);
+        
+        $this->model->trigger(UserEvent::EVENT_BEFORE_CONFIRMATION, $event);
         if ((bool)$this->model->updateAttributes(['confirmed_at' => time()])) {
-            $this->model->trigger(UserEvent::EVENT_AFTER_CONFIRMATION);
+            $this->model->trigger(UserEvent::EVENT_AFTER_CONFIRMATION, $event);
 
             return true;
         }

--- a/src/User/Service/UserConfirmationService.php
+++ b/src/User/Service/UserConfirmationService.php
@@ -14,9 +14,12 @@ namespace Da\User\Service;
 use Da\User\Contracts\ServiceInterface;
 use Da\User\Event\UserEvent;
 use Da\User\Model\User;
+use Da\User\Traits\MailAwareTrait;
 
 class UserConfirmationService implements ServiceInterface
 {
+    use MailAwareTrait;
+    
     protected $model;
 
     public function __construct(User $model)


### PR DESCRIPTION
…rEvent::EVENT_AFTER_CONFIRMATION

Bugfix for Model events UserEvent::EVENT_BEFORE_CREATE and UserEvent:…  …
…:EVENT_AFTER_CREATE

Feed instance of Da\User\Event\UserEvent to resolve error in event handlers:

TypeError
Argument 1 passed to {closure}() must be an instance of Da\User\Event\UserEvent, instance of yii\base\Event given

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | Bugfix for Model events UserEvent::EVENT_BEFORE_CONFIRMATION and Use…
