### PR TITLE
fix migration to work with SQL Server

### DIFF
--- a/src/User/Migration/m000000_000002_create_profile_table.php
+++ b/src/User/Migration/m000000_000002_create_profile_table.php
@@ -21,7 +21,7 @@ class m000000_000002_create_profile_table extends Migration
         $this->createTable(
             '{{%profile}}',
             [
-                'user_id' => $this->primaryKey(),
+                'user_id' => $this->integer()->notNull(),
                 'name' => $this->string(255),
                 'public_email' => $this->string(255),
                 'gravatar_email' => $this->string(255),
@@ -33,6 +33,8 @@ class m000000_000002_create_profile_table extends Migration
             ],
             MigrationHelper::resolveTableOptions($this->db->driverName)
         );
+
+        $this->addPrimaryKey('{{%profile_pk}}','{{%profile}}','user_id');
 
         $restrict = MigrationHelper::isMicrosoftSQLServer($this->db->driverName) ? 'NO ACTION' : 'RESTRICT';
 

--- a/src/User/Migration/m000000_000006_add_two_factor_fields.php
+++ b/src/User/Migration/m000000_000006_add_two_factor_fields.php
@@ -18,7 +18,7 @@ class m000000_000006_add_two_factor_fields extends Migration
     public function safeUp()
     {
         $this->addColumn('{{%user}}', 'auth_tf_key', $this->string(16));
-        $this->addColumn('{{%user}}', 'auth_tf_enabled', $this->boolean()->defaultValue(false));
+        $this->addColumn('{{%user}}', 'auth_tf_enabled', $this->boolean()->defaultValue(0));
     }
 
     public function safeDown()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | it shouldn't

When using SQL SERVER the migrations fail with 2 issues solved by this change:
1. there cannot be a foreign key that references 2 "auto increment" fields, and beside that the user_id in profile should not auto increment.
2. FALSE is not accepted as a default value for a "bit" field (it might be a MSSQL yii2 bug, I'm not sure ehere, this should work around the issue anyway)

This PR should solve both.