### PR TITLE
set username = email when authenticating with Google/Facebook/LinkdeI…

### DIFF
--- a/src/User/AuthClient/Facebook.php
+++ b/src/User/AuthClient/Facebook.php
@@ -31,6 +31,7 @@ class Facebook extends BaseFacebook implements AuthClientInterface
      */
     public function getUsername()
     {
-        return null;
+        /* returns the e-mail as it corresponds with the username */
+        return $this->getEmail();
     }
 }

--- a/src/User/AuthClient/Google.php
+++ b/src/User/AuthClient/Google.php
@@ -31,6 +31,7 @@ class Google extends BaseGoogle implements AuthClientInterface
      */
     public function getUsername()
     {
-        return null;
+        /* returns the e-mail as it corresponds with the username */
+        return $this->getEmail();
     }
 }

--- a/src/User/AuthClient/LinkedIn.php
+++ b/src/User/AuthClient/LinkedIn.php
@@ -31,6 +31,7 @@ class LinkedIn extends BaseLinkedIn implements AuthClientInterface
      */
     public function getUsername()
     {
-        return null;
+        /* returns the e-mail as it corresponds with the username */
+        return $this->getEmail();
     }
 }


### PR DESCRIPTION
Fix issue in #130 Unable to create account (with Google/Facebook)

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| Tests pass?   | dunno
| Fixed issues  | #130

It might be a partial fix as there are authClients which don't set the e-mail (which is required to be unique in the database)