### PR TITLE
if tables already exist (from dektrium installation) migrations will …

### DIFF
--- a/docs/installation/migration-guide-from-dektrium-tools.md
+++ b/docs/installation/migration-guide-from-dektrium-tools.md
@@ -54,6 +54,11 @@ In `config/web.php` remove *module > rbac* configuration and change the *modules
 *  In your extended model replace the `BaseUser` inheritance from `dektrium\user\models\User` to `Da\User\Model\User`
 *  If you had controller remapping replace the inheritance from `dektrium\user\controllers\XX` to `Da\User\Controller\XX`
 
+## Existing tables from dektrium migrations
+
+The migrations will check for existing tables (user,profile,social_account and token) and will simply do nothing if already found.
+This will permit to migrate existing production projects.
+
 ## Rbac migrations
 
 [yii2-rbac](https://github.com/dektrium/yii2-rbac) had a nice tool which are rbac migrations, which helped writing new permissions and roles.

--- a/src/User/Migration/m000000_000001_create_user_table.php
+++ b/src/User/Migration/m000000_000001_create_user_table.php
@@ -18,27 +18,30 @@ class m000000_000001_create_user_table extends Migration
 {
     public function safeUp()
     {
-        $this->createTable(
-            '{{%user}}',
-            [
-                'id' => $this->primaryKey(),
-                'username' => $this->string(255)->notNull(),
-                'email' => $this->string(255)->notNull(),
-                'password_hash' => $this->string(60)->notNull(),
-                'auth_key' => $this->string(32)->notNull(),
-                'unconfirmed_email' => $this->string(255),
-                'registration_ip' => $this->string(45),
-                'flags' => $this->integer()->notNull()->defaultValue('0'),
-                'confirmed_at' => $this->integer(),
-                'blocked_at' => $this->integer(),
-                'updated_at' => $this->integer()->notNull(),
-                'created_at' => $this->integer()->notNull(),
-            ],
-            MigrationHelper::resolveTableOptions($this->db->driverName)
-        );
+        /* Create the table only if does not exist */
+        if ($this->db->getTableSchema('{{%user}}')===null) {
+            $this->createTable(
+                '{{%user}}',
+                [
+                    'id' => $this->primaryKey(),
+                    'username' => $this->string(255)->notNull(),
+                    'email' => $this->string(255)->notNull(),
+                    'password_hash' => $this->string(60)->notNull(),
+                    'auth_key' => $this->string(32)->notNull(),
+                    'unconfirmed_email' => $this->string(255),
+                    'registration_ip' => $this->string(45),
+                    'flags' => $this->integer()->notNull()->defaultValue('0'),
+                    'confirmed_at' => $this->integer(),
+                    'blocked_at' => $this->integer(),
+                    'updated_at' => $this->integer()->notNull(),
+                    'created_at' => $this->integer()->notNull(),
+                ],
+                MigrationHelper::resolveTableOptions($this->db->driverName)
+            );
 
-        $this->createIndex('idx_user_username', '{{%user}}', 'username', true);
-        $this->createIndex('idx_user_email', '{{%user}}', 'email', true);
+            $this->createIndex('idx_user_username', '{{%user}}', 'username', true);
+            $this->createIndex('idx_user_email', '{{%user}}', 'email', true);
+        }
     }
 
     public function safeDown()

--- a/src/User/Migration/m000000_000002_create_profile_table.php
+++ b/src/User/Migration/m000000_000002_create_profile_table.php
@@ -18,25 +18,30 @@ class m000000_000002_create_profile_table extends Migration
 {
     public function safeUp()
     {
-        $this->createTable(
-            '{{%profile}}',
-            [
-                'user_id' => $this->primaryKey(),
-                'name' => $this->string(255),
-                'public_email' => $this->string(255),
-                'gravatar_email' => $this->string(255),
-                'gravatar_id' => $this->string(32),
-                'location' => $this->string(255),
-                'website' => $this->string(255),
-                'timezone' => $this->string(40),
-                'bio' => $this->text(),
-            ],
-            MigrationHelper::resolveTableOptions($this->db->driverName)
-        );
+        /* Create the table only if does not exist */
+        if ($this->db->getTableSchema('{{%profile}}')===null) {
+            $this->createTable(
+                '{{%profile}}',
+                [
+                    'user_id' => $this->integer()->notNull(),
+                    'name' => $this->string(255),
+                    'public_email' => $this->string(255),
+                    'gravatar_email' => $this->string(255),
+                    'gravatar_id' => $this->string(32),
+                    'location' => $this->string(255),
+                    'website' => $this->string(255),
+                    'timezone' => $this->string(40),
+                    'bio' => $this->text(),
+                ],
+                MigrationHelper::resolveTableOptions($this->db->driverName)
+            );
 
-        $restrict = MigrationHelper::isMicrosoftSQLServer($this->db->driverName) ? 'NO ACTION' : 'RESTRICT';
+            $this->addPrimaryKey('{{%profile_pk}}','{{%profile}}','user_id');
 
-        $this->addForeignKey('fk_profile_user', '{{%profile}}', 'user_id', '{{%user}}', 'id', 'CASCADE', $restrict);
+            $restrict = MigrationHelper::isMicrosoftSQLServer($this->db->driverName) ? 'NO ACTION' : 'RESTRICT';
+
+            $this->addForeignKey('fk_profile_user', '{{%profile}}', 'user_id', '{{%user}}', 'id', 'CASCADE', $restrict);
+        }
     }
 
     public function safeDown()

--- a/src/User/Migration/m000000_000003_create_social_account_table.php
+++ b/src/User/Migration/m000000_000003_create_social_account_table.php
@@ -18,40 +18,43 @@ class m000000_000003_create_social_account_table extends Migration
 {
     public function safeUp()
     {
-        $this->createTable(
-            '{{%social_account}}',
-            [
-                'id' => $this->primaryKey(),
-                'user_id' => $this->integer(),
-                'provider' => $this->string(255)->notNull(),
-                'client_id' => $this->string(255)->notNull(),
-                'code' => $this->string(32),
-                'email' => $this->string(255),
-                'username' => $this->string(255),
-                'data' => $this->text(),
-                'created_at' => $this->integer(),
-            ],
-            MigrationHelper::resolveTableOptions($this->db->driverName)
-        );
+        /* Create the table only if does not exist */
+        if ($this->db->getTableSchema('{{%social_account}}')===null) {
+            $this->createTable(
+                '{{%social_account}}',
+                [
+                    'id' => $this->primaryKey(),
+                    'user_id' => $this->integer(),
+                    'provider' => $this->string(255)->notNull(),
+                    'client_id' => $this->string(255)->notNull(),
+                    'code' => $this->string(32),
+                    'email' => $this->string(255),
+                    'username' => $this->string(255),
+                    'data' => $this->text(),
+                    'created_at' => $this->integer(),
+                ],
+                MigrationHelper::resolveTableOptions($this->db->driverName)
+            );
 
-        $this->createIndex(
-            'idx_social_account_provider_client_id',
-            '{{%social_account}}',
-            ['provider', 'client_id'],
-            true
-        );
+            $this->createIndex(
+                'idx_social_account_provider_client_id',
+                '{{%social_account}}',
+                ['provider', 'client_id'],
+                true
+            );
 
-        $this->createIndex('idx_social_account_code', '{{%social_account}}', 'code', true);
+            $this->createIndex('idx_social_account_code', '{{%social_account}}', 'code', true);
 
-        $this->addForeignKey(
-            'fk_social_account_user',
-            '{{%social_account}}',
-            'user_id',
-            '{{%user}}',
-            'id',
-            'CASCADE',
-            (MigrationHelper::isMicrosoftSQLServer($this->db->driverName) ? 'NO ACTION' : 'RESTRICT')
-        );
+            $this->addForeignKey(
+                'fk_social_account_user',
+                '{{%social_account}}',
+                'user_id',
+                '{{%user}}',
+                'id',
+                'CASCADE',
+                (MigrationHelper::isMicrosoftSQLServer($this->db->driverName) ? 'NO ACTION' : 'RESTRICT')
+            );
+        }
     }
 
     public function safeDown()

--- a/src/User/Migration/m000000_000004_create_token_table.php
+++ b/src/User/Migration/m000000_000004_create_token_table.php
@@ -18,22 +18,25 @@ class m000000_000004_create_token_table extends Migration
 {
     public function safeUp()
     {
-        $this->createTable(
-            '{{%token}}',
-            [
-                'user_id' => $this->integer(),
-                'code' => $this->string(32)->notNull(),
-                'type' => $this->smallInteger(6)->notNull(),
-                'created_at' => $this->integer()->notNull(),
-            ],
-            MigrationHelper::resolveTableOptions($this->db->driverName)
-        );
+        /* Create the table only if does not exist */
+        if ($this->db->getTableSchema('{{%token}}')===null) {
+            $this->createTable(
+                '{{%token}}',
+                [
+                    'user_id' => $this->integer(),
+                    'code' => $this->string(32)->notNull(),
+                    'type' => $this->smallInteger(6)->notNull(),
+                    'created_at' => $this->integer()->notNull(),
+                ],
+                MigrationHelper::resolveTableOptions($this->db->driverName)
+            );
 
-        $this->createIndex('idx_token_user_id_code_type', '{{%token}}', ['user_id', 'code', 'type'], true);
+            $this->createIndex('idx_token_user_id_code_type', '{{%token}}', ['user_id', 'code', 'type'], true);
 
-        $restrict = MigrationHelper::isMicrosoftSQLServer($this->db->driverName) ? 'NO ACTION' : 'RESTRICT';
+            $restrict = MigrationHelper::isMicrosoftSQLServer($this->db->driverName) ? 'NO ACTION' : 'RESTRICT';
 
-        $this->addForeignKey('fk_token_user', '{{%token}}', 'user_id', '{{%user}}', 'id', 'CASCADE', $restrict);
+            $this->addForeignKey('fk_token_user', '{{%token}}', 'user_id', '{{%user}}', 'id', 'CASCADE', $restrict);
+        }
     }
 
     public function safeDown()

--- a/src/User/Migration/m000000_000005_add_last_login_at.php
+++ b/src/User/Migration/m000000_000005_add_last_login_at.php
@@ -17,7 +17,11 @@ class m000000_000005_add_last_login_at extends Migration
 {
     public function safeUp()
     {
-        $this->addColumn('{{%user}}', 'last_login_at', $this->integer());
+        /* if it already exists do not add the field */
+        $schema = $this->db->getTableSchema('{{%user}}');
+        if (!in_array('last_login_at',$schema->columnNames)) {
+            $this->addColumn('{{%user}}', 'last_login_at', $this->integer());
+        }
     }
 
     public function safeDown()


### PR DESCRIPTION
…simply ignore the table creation [Issue #172]

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | should not
| Tests pass?   | yes
| Fixed issues  | #172 

This is an alternative approach (which I think it's better) to PR #174 
Last alternative would be to check if dektrium corresponding migration has already been applied (and skip if so)