### PR TITLE
Enh: Changed `View::render()` calls in views to use absolute paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 1.1.5 - Work in progress
+ - Enh: Changed `View::render()` calls in views to use absolute paths (ajmedway)
  - Fix #169: Fix bug in ReCaptchaComponent (BuTaMuH)
  - Fix #168: Fix spelling in russian language (EvgenyOrekhov)
  

--- a/src/User/resources/views/admin/_account.php
+++ b/src/User/resources/views/admin/_account.php
@@ -32,7 +32,7 @@ use yii\helpers\Html;
     ]
 ); ?>
 
-<?= $this->render('_user', ['form' => $form, 'user' => $user]) ?>
+<?= $this->render('/admin/_user', ['form' => $form, 'user' => $user]) ?>
 
 <div class="form-group">
     <div class="col-lg-offset-3 col-lg-9">

--- a/src/User/resources/views/admin/create.php
+++ b/src/User/resources/views/admin/create.php
@@ -96,7 +96,7 @@ $this->params['breadcrumbs'][] = $this->title;
                                     ]
                                 ); ?>
 
-                                <?= $this->render('_user', ['form' => $form, 'user' => $user]) ?>
+                                <?= $this->render('/admin/_user', ['form' => $form, 'user' => $user]) ?>
 
                                 <div class="form-group">
                                     <div class="col-lg-offset-3 col-lg-9">

--- a/src/User/resources/views/permission/create.php
+++ b/src/User/resources/views/permission/create.php
@@ -23,7 +23,7 @@ $this->params['breadcrumbs'][] = $this->title;
 <?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
 
 <?= $this->render(
-    '_form',
+    '/permission/_form',
     [
         'model' => $model,
         'unassignedItems' => $unassignedItems,

--- a/src/User/resources/views/permission/update.php
+++ b/src/User/resources/views/permission/update.php
@@ -23,7 +23,7 @@ $this->params['breadcrumbs'][] = $this->title;
 <?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
 
 <?= $this->render(
-    '_form',
+    '/permission/_form',
     [
         'model' => $model,
         'unassignedItems' => $unassignedItems,

--- a/src/User/resources/views/role/create.php
+++ b/src/User/resources/views/role/create.php
@@ -22,7 +22,7 @@ $this->params['breadcrumbs'][] = $this->title;
 <?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
 
 <?= $this->render(
-    '_form',
+    '/role/_form',
     [
         'model' => $model,
         'unassignedItems' => $unassignedItems,

--- a/src/User/resources/views/role/update.php
+++ b/src/User/resources/views/role/update.php
@@ -22,7 +22,7 @@ $this->params['breadcrumbs'][] = $this->title;
 <?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
 
 <?= $this->render(
-    '_form',
+    '/role/_form',
     [
         'model' => $model,
         'unassignedItems' => $unassignedItems,

--- a/src/User/resources/views/rule/create.php
+++ b/src/User/resources/views/rule/create.php
@@ -22,7 +22,7 @@ $this->params['breadcrumbs'][] = $this->title;
 <?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
 
 <?= $this->render(
-    '_form',
+    '/rule/_form',
     [
         'model' => $model,
     ]

--- a/src/User/resources/views/rule/update.php
+++ b/src/User/resources/views/rule/update.php
@@ -23,7 +23,7 @@ $this->params['breadcrumbs'][] = $this->title;
 <?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
 
 <?= $this->render(
-    '_form',
+    '/rule/_form',
     [
         'model' => $model,
     ]

--- a/src/User/resources/views/settings/account.php
+++ b/src/User/resources/views/settings/account.php
@@ -31,7 +31,7 @@ $module = Yii::$app->getModule('user');
 
 <div class="row">
     <div class="col-md-3">
-        <?= $this->render('_menu') ?>
+        <?= $this->render('/settings/_menu') ?>
     </div>
     <div class="col-md-9">
         <div class="panel panel-default">

--- a/src/User/resources/views/settings/networks.php
+++ b/src/User/resources/views/settings/networks.php
@@ -28,7 +28,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
 <div class="row">
     <div class="col-md-3">
-        <?= $this->render('_menu') ?>
+        <?= $this->render('/networks/_menu') ?>
     </div>
     <div class="col-md-9">
         <div class="panel panel-default">

--- a/src/User/resources/views/settings/profile.php
+++ b/src/User/resources/views/settings/profile.php
@@ -32,7 +32,7 @@ $timezoneHelper = $model->make(TimezoneHelper::class);
 
 <div class="row">
     <div class="col-md-3">
-        <?= $this->render('_menu') ?>
+        <?= $this->render('/profile/_menu') ?>
     </div>
     <div class="col-md-9">
         <div class="panel panel-default">

--- a/src/User/resources/views/shared/admin_layout.php
+++ b/src/User/resources/views/shared/admin_layout.php
@@ -32,7 +32,7 @@ use yii\helpers\Html;
                 <h3 class="panel-title"><?= Html::encode($this->title) ?></h3>
             </div>
             <div class="panel-body">
-                <?= $this->render('_menu') ?>
+                <?= $this->render('/shared/_menu') ?>
                 <?= $content ?>
             </div>
         </div>

--- a/src/User/resources/views/shared/message.php
+++ b/src/User/resources/views/shared/message.php
@@ -20,7 +20,7 @@ $this->title = $title;
 ?>
 
 <?= $this->render(
-    '_alert',
+    '/shared/_alert',
     [
         'module' => $module,
     ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
Maximised compatibility with view overrides, preventing "View not Found – yii\base\ViewNotFoundException" errors when a view is overridden that contains a call to `View::render()` and a relative path was specified
