### PR TITLE
#209 Doc fix. allowAccountDelete default value is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 1.1.5 - Work in progress
+ - Fix #209: Doc fix. allowAccountDelete default value is false (Dezinger)
  - Ehn #131: 2FA libraries now optional (maxxer)
  - Ehn #187: Add GDPR features (Eseperio)
  - Enh #184: Add `last-login-ip` capture capability (kartik-v)

--- a/docs/installation/configuration-options.md
+++ b/docs/installation/configuration-options.md
@@ -98,7 +98,7 @@ class SiteController extends Controller
 ```
 This will redirect the user to their account page until the password has been updated.
 
-#### allowAccountDelete (type: `boolean`, default: `true`)
+#### allowAccountDelete (type: `boolean`, default: `false`)
 
 If `true` users will be able to remove their own accounts. 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | #209 
