### PR TITLE
fix unpassable condition in EmailChangeService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 1.5.0 - Work in progress
+ - Fix: Fix condition in EmailChangeService (it was always false) (borisaeric)
  - Fix #198: Updated translations by quique, bizley, TonisOrmisson, guogan, Dezinger, maxxer, wautvda, mrbig00
  - Fix #209: Doc fix. allowAccountDelete default value is false (Dezinger)
  - Fix #211: Migration boolean default value set to FALSE instead 0 (Dezinger)

--- a/src/User/Model/User.php
+++ b/src/User/Model/User.php
@@ -65,7 +65,7 @@ class User extends ActiveRecord implements IdentityInterface
     use ContainerAwareTrait;
 
     // following constants are used on secured email changing process
-    const OLD_EMAIL_CONFIRMED = 0b1;
+    const OLD_EMAIL_CONFIRMED = 0b01;
     const NEW_EMAIL_CONFIRMED = 0b10;
 
     /**

--- a/src/User/Service/EmailChangeService.php
+++ b/src/User/Service/EmailChangeService.php
@@ -76,7 +76,7 @@ class EmailChangeService implements ServiceInterface
                     );
                 }
             }
-            if (($this->model->flags & User::NEW_EMAIL_CONFIRMED & $this->model->flags & User::OLD_EMAIL_CONFIRMED)
+            if ((($this->model->flags & User::NEW_EMAIL_CONFIRMED) && ($this->model->flags & User::OLD_EMAIL_CONFIRMED))
                 || $this->getModule()->emailChangeStrategy === MailChangeStrategyInterface::TYPE_DEFAULT
             ) {
                 $this->model->email = $this->model->unconfirmed_email;


### PR DESCRIPTION
| Q                    | A
| -------------------| ----------
| Is bugfix?        | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?    | yes
| Fixed issues   | - user is now able to change email by SECURE email change strategy properly
