### PR TITLE
DEV: remove html tags from GDPR CSV output null values

### DIFF
--- a/src/User/Controller/SettingsController.php
+++ b/src/User/Controller/SettingsController.php
@@ -265,8 +265,12 @@ class SettingsController extends Controller
             $user = Yii::$app->user->identity;
             $data = [$properties, []];
 
+            $formatter = Yii::$app->formatter;
+            // override the default html-specific format for nulls
+            $formatter->nullDisplay = "";
+
             foreach ($properties as $property) {
-                $data[1][] = Yii::$app->formatter->asText(ArrayHelper::getValue($user, $property));
+                $data[1][] = $formatter->asText(ArrayHelper::getValue($user, $property));
             }
 
             array_walk($data[0], function (&$value, $key) {


### PR DESCRIPTION
currently null values end up being in CSV: `<span class="not-set">(not set)</span>`
Which is HTML specific and not really good for CSV output.
