### PR TITLE
Add /user/settings/export to command list

### DIFF
--- a/docs/installation/available-actions.md
+++ b/docs/installation/available-actions.md
@@ -14,8 +14,9 @@ The following is the list of action provided by the module:
 - **/user/settings/account**      Displays account settings form (email, username, password)
 - **/user/settings/networks**     Displays social network accounts settings page
 - **/user/settings/confirm**      Confirms a new email (requires *id* and *token* query params)
-- **/user/settings/privacy**      Displays GDPR data page
-- **/user/settings/gdprdelete**   Displays delete personal data page
+- **/user/settings/privacy**      Displays GDPR data page
+- **/user/settings/export**       Download personal data in a comma separated values format
+- **/user/settings/gdprdelete**   Displays delete personal data page
 - **/user/profile/show**          Displays user's profile (requires *id* query param)
 - **/user/admin/index**           Displays user management interface
 - **/user/admin/create**          Displays create user form


### PR DESCRIPTION
Additional command who can be add to some permission must be displayed in common list

p.s.: So... How about a table decorator for this list?

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -
