### PR TITLE
Set verbs filter for force-password-change action as POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
  - Fix #195: UserCreateService: check if we're from web before setting flash message (maxxer)
  - Enh: Improvements to the admin responsive design (wautvda)
  - Enh: Replace the deprecated InvalidParamException in ClassMapHelper (TonisOrmisson)
- 
+ - Fix #242: Add POST filter for `admin/force-password-change` action (bscheshirwork)
+
 ## 1.1.4 - February 19, 2018
 - Enh: Check enableEmailConfirmation on registration (faenir)
 - Fix #154: Fix DateTime constructor with Unix timestamps (tonydspaniard)

--- a/src/User/Controller/AdminController.php
+++ b/src/User/Controller/AdminController.php
@@ -84,7 +84,8 @@ class AdminController extends Controller
                     'confirm' => ['post'],
                     'block' => ['post'],
                     'switch-identity' => ['post'],
-                    'password-reset' => ['post']
+                    'password-reset' => ['post'],
+                    'force-password-change' => ['post'],
                 ],
             ],
             'access' => [


### PR DESCRIPTION
This action must be executed once time.
In `view` we can see post method, but this check is not including in controller access filters
https://github.com/2amigos/yii2-usuario/blob/6aaa687e8155f922c51e32e0a8890f4260130760/src/User/resources/views/admin/index.php#L185

https://github.com/2amigos/yii2-usuario/blob/6aaa687e8155f922c51e32e0a8890f4260130760/src/User/Controller/AdminController.php#L80-L89

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
