### PR TITLE
Delete check for unexcepted property allowPasswordRecovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
  - Enh: Add controller module class reference (TonisOrmisson)
  - Enh: Replace the deprecated InvalidParamException in ClassMapHelper (TonisOrmisson)
  - Fix #242: Add POST filter for `admin/force-password-change` action (bscheshirwork)
+ - Fix #252: Delete check for unexpected property `allowPasswordRecovery` for resend email by admin (bscheshirwork)
 
 ## 1.1.4 - February 19, 2018
 - Enh: Check enableEmailConfirmation on registration (faenir)

--- a/src/User/resources/views/admin/index.php
+++ b/src/User/resources/views/admin/index.php
@@ -152,7 +152,7 @@ $module = Yii::$app->getModule('user');
                         return null;
                     },
                     'reset' => function ($url, $model) use ($module) {
-                        if(!$module->allowPasswordRecovery && $module->allowAdminPasswordRecovery) {
+                        if($module->allowAdminPasswordRecovery) {
                             return Html::a(
                                 '<span class="glyphicon glyphicon-flash"></span>',
                                 ['/user/admin/password-reset', 'id' => $model->id],


### PR DESCRIPTION
Properties `allowPasswordRecovery` and `allowAdminPasswordRecovery` must be undepended

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | #247 
