### PR TITLE
separate Yii Event and namespace Event

### DIFF
--- a/src/User/Bootstrap.php
+++ b/src/User/Bootstrap.php
@@ -25,7 +25,7 @@ use yii\console\Application as ConsoleApplication;
 use yii\i18n\PhpMessageSource;
 use yii\web\Application as WebApplication;
 
-use yii\base\Event;
+use yii\base\Event as YiiEvent;
 use Da\User\Event\FormEvent;
 use Da\User\Controller\SecurityController;
 
@@ -153,7 +153,7 @@ class Bootstrap implements BootstrapInterface
 
             // Attach an event to check if the password has expired
             if (!is_null(Yii::$app->getModule('user')->maxPasswordAge)) {
-                Event::on(SecurityController::class, FormEvent::EVENT_AFTER_LOGIN, function (FormEvent $event) {
+                YiiEvent::on(SecurityController::class, FormEvent::EVENT_AFTER_LOGIN, function (FormEvent $event) {
                     $user = $event->form->user;
                     if ($user->password_age >= Yii::$app->getModule('user')->maxPasswordAge) {
                         // Force password change


### PR DESCRIPTION
add some differences between `Event`


`use yii\base\Event as YiiEvent;`
inside a
`namespace Da\User;` within nested namespace `Event` (`Da\User\Event\..`)



| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | 
