### PR TITLE
Rename gdprdelete action to gdpr-delete (actionGdprDelete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
  - Fix #242: Add POST filter for `admin/force-password-change` action (bscheshirwork)
  - Fix #252: Delete check for unexpected property `allowPasswordRecovery` for resend email by admin (bscheshirwork)
  - Fix #254: Rename `GDPR` properties to `lowerCamelCase` style (bscheshirwork)
+ - Fix #258: Rename `GDPR` delete action to `lowerCamelCase`/`dash` style (bscheshirwork)
 
 ## 1.1.4 - February 19, 2018
 - Enh: Check enableEmailConfirmation on registration (faenir)

--- a/docs/installation/available-actions.md
+++ b/docs/installation/available-actions.md
@@ -20,7 +20,7 @@ The following is the list of action provided by the module:
 | **/user/settings/delete** | Delete self account | | POST only
 | **/user/settings/disconnect** | Disconnect social account | | POST only
 | **/user/settings/export** | Download personal data in a comma separated values format
-| **/user/settings/gdprdelete** | Displays delete personal data page |
+| **/user/settings/gdpr-delete** | Displays delete personal data page |
 | **/user/settings/networks** | Displays social network accounts settings page
 | **/user/settings/privacy** | Displays GDPR data page
 | **/user/settings/profile** | Displays profile settings form

--- a/src/User/Controller/SettingsController.php
+++ b/src/User/Controller/SettingsController.php
@@ -107,7 +107,7 @@ class SettingsController extends Controller
                             'export',
                             'networks',
                             'privacy',
-                            'gdprdelete',
+                            'gdpr-delete',
                             'disconnect',
                             'delete',
                             'two-factor',
@@ -167,7 +167,7 @@ class SettingsController extends Controller
         ]);
     }
 
-    public function actionGdprdelete()
+    public function actionGdprDelete()
     {
         if (!$this->module->enableGdprCompliance)
             throw new NotFoundHttpException();
@@ -220,7 +220,7 @@ class SettingsController extends Controller
 
         }
 
-        return $this->render('gdprdelete', [
+        return $this->render('gdpr-delete', [
             'model' => $form,
         ]);
     }

--- a/src/User/resources/views/settings/gdpr-delete.php
+++ b/src/User/resources/views/settings/gdpr-delete.php
@@ -10,6 +10,7 @@
 
 use yii\widgets\ActiveForm;
 use yii\helpers\Html;
+
 /* @var $model \Da\User\Form\GdprDeleteForm */
 ?>
 
@@ -46,7 +47,7 @@ use yii\helpers\Html;
                 <hr>
                 <div class="row">
                     <div class="col-md-12 text-center">
-                        <?= Html::a(Yii::t('usuario','Back to privacy settings'),['/user/settings/privacy'],['class'=>'btn btn-info']) ?>
+                        <?= Html::a(Yii::t('usuario', 'Back to privacy settings'), ['/user/settings/privacy'], ['class' => 'btn btn-info']) ?>
                     </div>
                 </div>
                 <?php

--- a/src/User/resources/views/settings/privacy.php
+++ b/src/User/resources/views/settings/privacy.php
@@ -54,7 +54,7 @@ $this->title = Yii::t('usuario', 'Privacy settings');
                             ) ?>
                         <?php else:
                             echo Html::a(Yii::t('usuario', 'Delete'),
-                                ['/user/settings/gdprdelete'],
+                                ['/user/settings/gdpr-delete'],
                                 [
                                     'class' => 'btn btn-danger',
                                     'id' => 'gdpr-del-button',

--- a/tests/functional/GdprCest.php
+++ b/tests/functional/GdprCest.php
@@ -141,7 +141,7 @@ class GdprCest
         $I->amOnRoute('/user/settings/privacy');
         $I->see('Export my data', 'h3');
         $I->see('Delete my account', 'h3');
-        $I->amOnRoute('/user/settings/gdprdelete');
+        $I->amOnRoute('/user/settings/gdpr-delete');
         $I->fillField('#gdprdeleteform-password','wrongpassword');
         $I->click('Delete');
         $I->see('Invalid password');


### PR DESCRIPTION
This action is broke yii2 naming of actions. We must repair it.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  |no
| Breaks BC?    | no relise has been publish within this name. 
| Tests pass?   | yes/no
| Fixed issues  | #258
