### PR TITLE
Fixed broken regex character class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
  - Enh #249: Show message `email send if possible` any time on reset password request (bscheshirwork)
  - Enh #282: Allows customization of controller namespace (maxxer)
  - Enh #303: Added French translation (pde159)
- - Fix: Fixed broken regex character class (CheckeredFlag)
+ - Fix #304: Fixed broken regex character class (CheckeredFlag)
 
 ## 1.1.4 - February 19, 2018
 - Enh: Check enableEmailConfirmation on registration (faenir)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
  - Enh #249: Show message `email send if possible` any time on reset password request (bscheshirwork)
  - Enh #282: Allows customization of controller namespace (maxxer)
  - Enh #303: Added French translation (pde159)
+ - Fix: Fixed broken regex character class (CheckeredFlag)
 
 ## 1.1.4 - February 19, 2018
 - Enh: Check enableEmailConfirmation on registration (faenir)

--- a/src/User/Model/AbstractAuthItem.php
+++ b/src/User/Model/AbstractAuthItem.php
@@ -98,7 +98,7 @@ abstract class AbstractAuthItem extends Model
         return [
             ['itemName', 'safe'],
             ['name', 'required'],
-            ['name', 'match', 'pattern' => '/^[\w][\w-.:]+[\w]$/'],
+            ['name', 'match', 'pattern' => '/^[\w][\w.:-]+[\w]$/'],
             [['name', 'description', 'rule'], 'trim'],
             [
                 'name',

--- a/src/User/Model/Rule.php
+++ b/src/User/Model/Rule.php
@@ -53,7 +53,7 @@ class Rule extends Model
         return [
             [['name', 'className'], 'trim'],
             [['name', 'className'], 'required'],
-            [['name', 'previousName'], 'match', 'pattern' => '/^[\w][\w-.:]+[\w]$/'],
+            [['name', 'previousName'], 'match', 'pattern' => '/^[\w][\w.:-]+[\w]$/'],
             [['name'], RbacRuleNameValidator::class, 'previousName' => $this->previousName],
             [['className'], RbacRuleValidator::class],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | ?
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

These files reference invalid regex character classes by including a hyphen which is intended to be a literal, but gets interpreted as an invalid range.  Moving the hyphen to the last character in the class fixes it.

This fixes the Ajax error when submitting: user/role/create