### PR TITLE
Added support for sqlite3 (just allowed it in MigrationHelper)

### DIFF
--- a/src/User/Helper/MigrationHelper.php
+++ b/src/User/Helper/MigrationHelper.php
@@ -32,6 +32,8 @@ class MigrationHelper
             case 'mssql':
             case 'sqlsrv':
                 return null;
+            case 'sqlite':
+                return null;
             default:
                 throw new RuntimeException('Your database is not supported!');
         }
@@ -55,6 +57,8 @@ class MigrationHelper
             case 'mssql':
             case 'sqlsrv':
                 return 'sqlsrv';
+            case 'sqlite':
+                return $driverName;
             default:
                 throw new RuntimeException('Your database is not supported!');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | Half of them so far
| Fixed issues  | #315

So far, I have not hit any error using sqlite out of the box, I mean, even without the package santilin/yii2-sqlite3-full-suppport.

I have created a test app to run the tests and half of them worked successfully, while the other failed for problems unrelated to sqlite.

To run the test inside this project, a sqlite3 dump should be created that mimics the mysqlone.

Should any test fail due to sqlite3 lack of support, we could try the sqlite3-full-support package, though I think it is not very probable.