### PR TITLE
Fixed rule (changed to boolean) for the user auth_tf_enabled field

### DIFF
--- a/src/User/Model/User.php
+++ b/src/User/Model/User.php
@@ -248,7 +248,7 @@ class User extends ActiveRecord implements IdentityInterface
             // two factor auth rules
             'twoFactorSecretTrim' => ['auth_tf_key', 'trim'],
             'twoFactorSecretLength' => ['auth_tf_key', 'string', 'max' => 16],
-            'twoFactorEnabledNumber' => ['auth_tf_enabled', 'integer']
+            'twoFactorEnabledNumber' => ['auth_tf_enabled', 'boolean']
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | one test that failed on sqlite3 passes now

The rule for field auth_tf_enabled was set to integer, which in sqlite3 databases failed.