### PR TITLE
#347 Only pass fields that are known to be in the User Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+ - Fix #347: Only pass fields known to User model in registrationControl->actionRegister() (BillHeaton)
+ - Fix #346: Update ReCaptcha guide to not use AJAX  (BillHeaton)
+ - Fix #345: Update ReCaptcha guide to add scenarios() in recoveryForm  (BillHeaton)
  - Fix #307: Fix French translation (arollmann)
  - Fix #316: Fix new response from Google OAuth Api (Julian-B90)
  - Fix #321: Fix new response from LinkedIn OAuth Api (tonydspaniard) 

--- a/src/User/Controller/RegistrationController.php
+++ b/src/User/Controller/RegistrationController.php
@@ -102,9 +102,14 @@ class RegistrationController extends Controller
 
         if ($form->load(Yii::$app->request->post()) && $form->validate()) {
             $this->trigger(FormEvent::EVENT_BEFORE_REGISTER, $event);
+
             /** @var User $user */
-            $user = $this->make(User::class, [], $form->attributes);
-            $user->setScenario('register');
+            $user = $this->make(User::class, [],
+                  [ 'email'    => $form->attributes['email'],
+                    'username' => $form->attributes['username'],
+                    'password' => $form->attributes['password']
+                  ]);            $user->setScenario('register');
+
             $mailService = MailFactory::makeWelcomeMailerService($user);
 
             if ($this->make(UserRegisterService::class, [$user, $mailService])->run()) {

--- a/src/User/Controller/RegistrationController.php
+++ b/src/User/Controller/RegistrationController.php
@@ -88,6 +88,9 @@ class RegistrationController extends Controller
         ];
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function actionRegister()
     {
         if (!$this->module->enableRegistration) {
@@ -104,12 +107,18 @@ class RegistrationController extends Controller
             $this->trigger(FormEvent::EVENT_BEFORE_REGISTER, $event);
 
             /** @var User $user */
-            $user = $this->make(User::class, [],
-                  [ 'email'    => $form->attributes['email'],
-                    'username' => $form->attributes['username'],
-                    'password' => $form->attributes['password']
-                  ]);            $user->setScenario('register');
 
+            // Create a temporay $user so we can get the attributes, then get
+            // the intersection between the $form fields  and the $user fields.
+            $user = $this->make(User::class, [] );
+            $fields = array_intersect_key($form->attributes, $user->attributes);
+
+             // Becomes password_hash
+            $fields['password'] = $form['password'];
+
+            $user = $this->make(User::class, [], $fields );
+
+            $user->setScenario('register');
             $mailService = MailFactory::makeWelcomeMailerService($user);
 
             if ($this->make(UserRegisterService::class, [$user, $mailService])->run()) {
@@ -138,6 +147,9 @@ class RegistrationController extends Controller
         return $this->render('register', ['model' => $form, 'module' => $this->module]);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function actionConnect($code)
     {
         /** @var SocialNetworkAccount $account */
@@ -179,6 +191,9 @@ class RegistrationController extends Controller
         );
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function actionConfirm($id, $code)
     {
         /** @var User $user */
@@ -215,6 +230,9 @@ class RegistrationController extends Controller
         );
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function actionResend()
     {
         if ($this->module->enableEmailConfirmation === false) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #345, #346, #347

Adding any field to the registration form fails because the container doesn't know what to do with the extra field(s). The solution is to only pass the fields that the user model expects to show up.
