### PR TITLE
Fix postgres rule unserialization

### DIFF
--- a/src/User/resources/views/rule/index.php
+++ b/src/User/resources/views/rule/index.php
@@ -35,9 +35,11 @@ $this->params['breadcrumbs'][] = $this->title;
                 'attribute' => 'className',
                 'label' => Yii::t('usuario', 'Class'),
                 'value' => function ($row) {
-                    $rule = unserialize($row['data']);
+                    if (!isset($row['data']) || ($data = @unserialize(is_resource($row['data']) ? stream_get_contents($row['data']) : $row['data'])) === false) {
+                        $data = null;
+                    }
 
-                    return get_class($rule);
+                    return get_class($data);
                 },
                 'options' => [
                     'style' => 'width: 20%'


### PR DESCRIPTION
Yii2 migration for Postgres uses bytea for field "data" (see: https://github.com/yiisoft/yii2/commit/23790272dc561aacf2070cbbda396f49e44cbb7d#diff-9dc218c5c0834622090067e24bb745073a454b843a5e150d1498af80ebdd73fa) and bytea is resource in php so unserialize will throw error. 

This code is taken from Yii2 DbManager:
https://github.com/yiisoft/yii2/blob/master/framework/rbac/DbManager.php#L449