### PR TITLE
Moved event to correct place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Enh #387: Added Persian translation (hadi-aj)
  - Fix #384: Delete flash messages after consuming (cgsmith)
  - Enh: Added SK translations (snickom)
+ - Fix #430: Moved EVENT_BEFORE_PROFILE_UPDATE to correct place (eluhr)
 
 ## 1.5.1 April 5, 2020
  - Fix #370: Extending view fix (effsoft)

--- a/src/User/Controller/AdminController.php
+++ b/src/User/Controller/AdminController.php
@@ -189,8 +189,8 @@ class AdminController extends Controller
         $this->make(AjaxRequestModelValidator::class, [$profile])->validate();
 
         if ($profile->load(Yii::$app->request->post())) {
+            $this->trigger(UserEvent::EVENT_BEFORE_PROFILE_UPDATE, $event);
             if ($profile->save()) {
-                $this->trigger(UserEvent::EVENT_BEFORE_PROFILE_UPDATE, $event);
                 Yii::$app->getSession()->setFlash('success', Yii::t('usuario', 'Profile details have been updated'));
                 $this->trigger(UserEvent::EVENT_AFTER_PROFILE_UPDATE, $event);
 
@@ -330,7 +330,7 @@ class AdminController extends Controller
 
         return $this->redirect(['index']);
     }
-    
+
     /**
      * Forces the user to change password at next login
      * @param integer $id


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | Moved EVENT_BEFORE_PROFILE_UPDATE trigger to the correct place (similar to [SettingsController](https://github.com/2amigos/yii2-usuario/blob/master/src/User/Controller/SettingsController.php#L147))

I assume this is an unintentional error, since the documentation describes the event as follows: _[Occurs before a user's profile has been updated](https://github.com/2amigos/yii2-usuario/blob/master/docs/events/user-events.md)_ . Feel free to close this PR if I am wrong.