### PR TITLE
FIX allow password_changed_at to be saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Enh #387: Added Persian translation (hadi-aj)
  - Fix #384: Delete flash messages after consuming (cgsmith)
  - Enh: Added SK translations (snickom)
+ - Fix: allow password_changed_at to be saved when reseting password (p4blojf)
 
 ## 1.5.1 April 5, 2020
  - Fix #370: Extending view fix (effsoft)

--- a/src/User/Service/ResetPasswordService.php
+++ b/src/User/Service/ResetPasswordService.php
@@ -31,6 +31,6 @@ class ResetPasswordService implements ServiceInterface
     public function run()
     {
         $this->model->password = $this->password;
-        return (bool)$this->model->save(false, ['password_hash']);
+        return (bool)$this->model->save(false, ['password_hash','password_changed_at']);
     }
 }


### PR DESCRIPTION
Issue When recovering password, password_changed_at is not saved.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | na
