### PR TITLE
fixed issue: user login events not triggered on ajax requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## work in progress
+ - Fix user login events not triggered on ajax requests (TonisOrmisson)
  - Enh: Added minimum requirements when a new password is automatically generated (MatteoF96)
  - Fix #380: Avoid rewriting AccessRule::matchRole (maxxer)
  - Fix #378: Add module attribute 'disableIpLogging' (jkmssoft)

--- a/src/User/Controller/SecurityController.php
+++ b/src/User/Controller/SecurityController.php
@@ -125,7 +125,14 @@ class SecurityController extends Controller
         if (Yii::$app->request->isAjax && $form->load(Yii::$app->request->post())) {
             Yii::$app->response->format = Response::FORMAT_JSON;
 
-            return ActiveForm::validate($form);
+            $this->trigger(FormEvent::EVENT_BEFORE_LOGIN, $event);
+            $errors = ActiveForm::validate($form);
+            if(empty($errors)) {
+                $this->trigger(FormEvent::EVENT_AFTER_LOGIN, $event);
+                return $errors;
+            }
+            $this->trigger(FormEvent::EVENT_FAILED_LOGIN, $event);
+            return $errors;
         }
 
         if ($form->load(Yii::$app->request->post())) {
@@ -150,7 +157,7 @@ class SecurityController extends Controller
             }
             else
             {
-                $this->trigger(FormEvent::EVENT_FAILED_LOGIN, $event);    
+                $this->trigger(FormEvent::EVENT_FAILED_LOGIN, $event);
             }
         }
 


### PR DESCRIPTION
Currently the Login events only get triggered on non-ajax requests. The login by default happens via ajax validation and the Login events are not triggered at all. Added the event triggers to ajax validation request.