### PR TITLE
Remove default swiftmailer dependency

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
             fail-fast: false
             matrix:
                 operating-system: ['ubuntu-latest']
-                php-versions: ['8.1', '8.0','7.4','7.3', '7.2','7.1','7.0', '5.6']
+                php-versions: ['8.1', '8.0','7.4']
 
         services:
             mariadb:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Yii 2 Usuario Extension
 [![Latest Stable Version](https://poser.pugx.org/2amigos/yii2-usuario/version)](https://packagist.org/packages/2amigos/yii2-usuario)
 [![Total Downloads](https://poser.pugx.org/2amigos/yii2-usuario/downloads)](https://packagist.org/packages/2amigos/yii2-usuario)
 [![Build Status](https://github.com/2amigos/yii2-usuario/actions/workflows/php.yml/badge.svg)](https://github.com/2amigos/yii2-usuario/actions/)
-
 [![Latest Unstable Version](https://poser.pugx.org/2amigos/yii2-usuario/v/unstable)](//packagist.org/packages/2amigos/yii2-usuario)  
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/2amigos/yii2-usuario/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/2amigos/yii2-usuario/?branch=master)
 

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -11,7 +11,7 @@ settings:
 modules:
     config:
         Db:
-            dsn: 'mysql:host=usuario_db;dbname=app_test'
+            dsn: 'mysql:host=127.0.0.1;dbname=yii2-usuario-test'
             user: 'root'
             password: 'password'
             dump: tests/_data/schema.sql

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -11,7 +11,7 @@ settings:
 modules:
     config:
         Db:
-            dsn: 'mysql:host=127.0.0.1;dbname=yii2-usuario-test'
+            dsn: 'mysql:host=usuario_db;dbname=app_test'
             user: 'root'
             password: 'password'
             dump: tests/_data/schema.sql

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,8 @@
         "2amigos/qrcode-library": "Needed if you want to enable 2FA with QR Code generation. Require version ^1.1"
     },
     "require-dev": {
+        "php": ">=7.4",
+
         "yiisoft/yii2-symfonymailer": "~2.0.0",
         "friendsofphp/php-cs-fixer": "^2.3",
         "squizlabs/php_codesniffer": "*",

--- a/composer.json
+++ b/composer.json
@@ -44,14 +44,15 @@
         "2amigos/yii2-selectize-widget": "^1.1",
         "yiisoft/yii2-authclient": "^2.1",
         "yiisoft/yii2-httpclient": "^2.0",
-        "yiisoft/yii2-bootstrap": "^2.0",
-        "yiisoft/yii2-swiftmailer": "^2.0"
+        "yiisoft/yii2-bootstrap": "^2.0"
     },
     "suggest": {
+        "yiisoft/yii2-symfonymailer": "A mailer driver is needed to send e-mails. Older versions use abandoned Swiftmailer which can be replaced with symfonymailer",
         "2amigos/2fa-library": "Needed if you want to enable 2 Factor Authentication. Require version ^1.0",
         "2amigos/qrcode-library": "Needed if you want to enable 2FA with QR Code generation. Require version ^1.1"
     },
     "require-dev": {
+        "yiisoft/yii2-symfonymailer": "~2.0.0",
         "friendsofphp/php-cs-fixer": "^2.3",
         "squizlabs/php_codesniffer": "*",
         "phpmd/phpmd": "@stable",

--- a/tests/_app/config/test.php
+++ b/tests/_app/config/test.php
@@ -24,7 +24,11 @@ return [
         ],
         'db' => require __DIR__ . '/db.php',
         'mailer' => [
-            'useFileTransport' => true,
+            'messageClass' => \yii\symfonymailer\Message::class,
+            [
+                'class' => \yii\symfonymailer\Mailer::class,
+            ],
+            'useFileTransport' => false
         ],
         'urlManager' => [
             'showScriptName' => true,

--- a/tests/functional/GdprCest.php
+++ b/tests/functional/GdprCest.php
@@ -102,7 +102,7 @@ class GdprCest
         /** @var \yii\mail\MessageInterface $message */
         $message = $I->grabLastSentEmail();
         $I->assertArrayHasKey($user->email, $message->getTo());
-        $I->assertStringContainsString(Html::encode($token->getUrl()), utf8_encode(quoted_printable_decode($message->getSwiftMessage()->toString())));
+        $I->assertStringContainsString(Html::encode($token->getUrl()), utf8_encode(quoted_printable_decode($message->toString())));
         $I->assertFalse($user->isConfirmed);
     }
 
@@ -123,7 +123,7 @@ class GdprCest
         /** @var \yii\mail\MessageInterface $message */
         $message = $I->grabLastSentEmail();
         $I->assertArrayHasKey($user->email, $message->getTo());
-        $I->assertStringContainsString('We have generated a password for you', utf8_encode(quoted_printable_decode($message->getSwiftMessage()->toString())));
+        $I->assertStringContainsString('We have generated a password for you', utf8_encode(quoted_printable_decode($message->toString())));
     }
 
 

--- a/tests/functional/GdprCest.php
+++ b/tests/functional/GdprCest.php
@@ -97,9 +97,9 @@ class GdprCest
         $I->amOnRoute('/user/registration/register');
         $this->register($I, 'tester@example.com', 'tester', 'tester');
         $I->see('Your account has been created and a message with further instructions has been sent to your email');
-        $user = $I->grabRecord(User::className(), ['email' => 'tester@example.com']);
-        $token = $I->grabRecord(Token::className(), ['user_id' => $user->id, 'type' => Token::TYPE_CONFIRMATION]);
-        /** @var yii\swiftmailer\Message $message */
+        $user = $I->grabRecord(User::class, ['email' => 'tester@example.com']);
+        $token = $I->grabRecord(Token::class, ['user_id' => $user->id, 'type' => Token::TYPE_CONFIRMATION]);
+        /** @var \yii\mail\MessageInterface $message */
         $message = $I->grabLastSentEmail();
         $I->assertArrayHasKey($user->email, $message->getTo());
         $I->assertStringContainsString(Html::encode($token->getUrl()), utf8_encode(quoted_printable_decode($message->getSwiftMessage()->toString())));
@@ -118,9 +118,9 @@ class GdprCest
         $I->amOnRoute('/user/registration/register');
         $this->register($I, 'tester@example.com', 'tester');
         $I->see('Your account has been created');
-        $user = $I->grabRecord(User::className(), ['email' => 'tester@example.com']);
+        $user = $I->grabRecord(User::class, ['email' => 'tester@example.com']);
         $I->assertEquals('tester', $user->username);
-        /** @var yii\swiftmailer\Message $message */
+        /** @var \yii\mail\MessageInterface $message */
         $message = $I->grabLastSentEmail();
         $I->assertArrayHasKey($user->email, $message->getTo());
         $I->assertStringContainsString('We have generated a password for you', utf8_encode(quoted_printable_decode($message->getSwiftMessage()->toString())));

--- a/tests/functional/RecoveryCept.php
+++ b/tests/functional/RecoveryCept.php
@@ -43,7 +43,7 @@ $message = $I->grabLastSentEmail();
 $I->assertArrayHasKey($user->email, $message->getTo());
 $I->assertStringContainsString(
     Html::encode($token->getUrl()),
-    utf8_encode(quoted_printable_decode($message->getSwiftMessage()->toString()))
+    utf8_encode(quoted_printable_decode($message->toString()))
 );
 
 $I->amGoingTo('reset password with invalid token');

--- a/tests/functional/RecoveryCept.php
+++ b/tests/functional/RecoveryCept.php
@@ -36,9 +36,9 @@ $I->fillField('#recoveryform-email', $user->email);
 $I->click('Continue');
 
 $I->see('An email with instructions to create a new password has been sent to ' . $user->email);
-$user = $I->grabRecord(User::className(), ['email' => $user->email]);
-$token = $I->grabRecord(Token::className(), ['user_id' => $user->id, 'type' => Token::TYPE_RECOVERY]);
-/** @var yii\swiftmailer\Message $message */
+$user = $I->grabRecord(User::class, ['email' => $user->email]);
+$token = $I->grabRecord(Token::class, ['user_id' => $user->id, 'type' => Token::TYPE_RECOVERY]);
+/** @var \yii\mail\MessageInterface $message */
 $message = $I->grabLastSentEmail();
 $I->assertArrayHasKey($user->email, $message->getTo());
 $I->assertStringContainsString(

--- a/tests/functional/RegistrationCest.php
+++ b/tests/functional/RegistrationCest.php
@@ -68,9 +68,9 @@ class RegistrationCest
         $I->amOnRoute('/user/registration/register');
         $this->register($I, 'tester@example.com', 'tester', 'tester');
         $I->see('Your account has been created and a message with further instructions has been sent to your email');
-        $user = $I->grabRecord(User::className(), ['email' => 'tester@example.com']);
-        $token = $I->grabRecord(Token::className(), ['user_id' => $user->id, 'type' => Token::TYPE_CONFIRMATION]);
-        /** @var yii\swiftmailer\Message $message */
+        $user = $I->grabRecord(User::class, ['email' => 'tester@example.com']);
+        $token = $I->grabRecord(Token::class, ['user_id' => $user->id, 'type' => Token::TYPE_CONFIRMATION]);
+        /** @var \yii\mail\MessageInterface $message */
         $message = $I->grabLastSentEmail();
         $I->assertArrayHasKey($user->email, $message->getTo());
         $I->assertStringContainsString(Html::encode($token->getUrl()), utf8_encode(quoted_printable_decode($message->getSwiftMessage()->toString())));
@@ -91,7 +91,7 @@ class RegistrationCest
         $I->see('Your account has been created');
         $user = $I->grabRecord(User::className(), ['email' => 'tester@example.com']);
         $I->assertEquals('tester', $user->username);
-        /** @var yii\swiftmailer\Message $message */
+        /** @var \yii\mail\MessageInterface $message */
         $message = $I->grabLastSentEmail();
         $I->assertArrayHasKey($user->email, $message->getTo());
         $I->assertStringContainsString('We have generated a password for you', utf8_encode(quoted_printable_decode($message->getSwiftMessage()->toString())));

--- a/tests/functional/RegistrationCest.php
+++ b/tests/functional/RegistrationCest.php
@@ -73,7 +73,7 @@ class RegistrationCest
         /** @var \yii\mail\MessageInterface $message */
         $message = $I->grabLastSentEmail();
         $I->assertArrayHasKey($user->email, $message->getTo());
-        $I->assertStringContainsString(Html::encode($token->getUrl()), utf8_encode(quoted_printable_decode($message->getSwiftMessage()->toString())));
+        $I->assertStringContainsString(Html::encode($token->getUrl()), utf8_encode(quoted_printable_decode($message->toString())));
         $I->assertFalse($user->isConfirmed);
     }
 
@@ -94,7 +94,7 @@ class RegistrationCest
         /** @var \yii\mail\MessageInterface $message */
         $message = $I->grabLastSentEmail();
         $I->assertArrayHasKey($user->email, $message->getTo());
-        $I->assertStringContainsString('We have generated a password for you', utf8_encode(quoted_printable_decode($message->getSwiftMessage()->toString())));
+        $I->assertStringContainsString('We have generated a password for you', utf8_encode(quoted_printable_decode($message->toString())));
     }
 
     protected function register(FunctionalTester $I, $email, $username = null, $password = null) {

--- a/tests/functional/SettingsCept.php
+++ b/tests/functional/SettingsCept.php
@@ -39,7 +39,7 @@ $token = $I->grabRecord(Token::class, ['user_id' => $user->id, 'type' => Token::
 /** @var \yii\mail\MessageInterface $message */
 $message = $I->grabLastSentEmail();
 $I->assertArrayHasKey($user->unconfirmed_email, $message->getTo());
-$I->assertStringContainsString(Html::encode($token->getUrl()), utf8_encode(quoted_printable_decode($message->getSwiftMessage()->toString())));
+$I->assertStringContainsString(Html::encode($token->getUrl()), utf8_encode(quoted_printable_decode($message->toString())));
 Yii::$app->user->logout();
 
 $I->amGoingTo('log in using new email address before clicking the confirmation link');

--- a/tests/functional/SettingsCept.php
+++ b/tests/functional/SettingsCept.php
@@ -34,9 +34,9 @@ $I->click('Save');
 $I->seeRecord(User::className(), ['email' => $user->email, 'unconfirmed_email' => 'new_user@example.com']);
 
 $I->see('A confirmation message has been sent to your new email address');
-$user = $I->grabRecord(User::className(), ['id' => $user->id]);
-$token = $I->grabRecord(Token::className(), ['user_id' => $user->id, 'type' => Token::TYPE_CONFIRM_NEW_EMAIL]);
-/** @var yii\swiftmailer\Message $message */
+$user = $I->grabRecord(User::class, ['id' => $user->id]);
+$token = $I->grabRecord(Token::class, ['user_id' => $user->id, 'type' => Token::TYPE_CONFIRM_NEW_EMAIL]);
+/** @var \yii\mail\MessageInterface $message */
 $message = $I->grabLastSentEmail();
 $I->assertArrayHasKey($user->unconfirmed_email, $message->getTo());
 $I->assertStringContainsString(Html::encode($token->getUrl()), utf8_encode(quoted_printable_decode($message->getSwiftMessage()->toString())));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Tests pass?   | yes

The swiftmailer is abandoned. Symphonymailer is the next suggested package. 

- I replaced all swiftmailer references with generic interface references. 
- Removed Swiftmailer as required package and added Symphonymailer as suggested package
- added Symphonymailer as default for development

This all should enable to:
- keep using Swiftmailer on current systems (needs to be required via composer otherwise though)
- remove the abandoned dependency

and:
since the Symphonymailer depends on php7.4 at lowest, I added php7.4 as minimum for development env as well as tests matrix. 
