### PR TITLE
Fixed issue: remove after/before login events from ajax LoginForm val…

### DIFF
--- a/src/User/Controller/SecurityController.php
+++ b/src/User/Controller/SecurityController.php
@@ -125,10 +125,8 @@ class SecurityController extends Controller
         if (Yii::$app->request->isAjax && $form->load(Yii::$app->request->post())) {
             Yii::$app->response->format = Response::FORMAT_JSON;
 
-            $this->trigger(FormEvent::EVENT_BEFORE_LOGIN, $event);
             $errors = ActiveForm::validate($form);
             if(empty($errors)) {
-                $this->trigger(FormEvent::EVENT_AFTER_LOGIN, $event);
                 return $errors;
             }
             $this->trigger(FormEvent::EVENT_FAILED_LOGIN, $event);


### PR DESCRIPTION
…idation, only validation is done there

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| Tests pass?   | yes/no

Currently the Befor/after login events get triggered twice, on ajax validation and then also on POST

related to #450