### PR TITLE
Change Float to String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
  - Fix: allow password_changed_at to be saved when reseting password (p4blojf)
  - Fix #430: Moved EVENT_BEFORE_PROFILE_UPDATE to correct place (eluhr)
 
+## 1.5.2 July 27, 2022
+ - Fix #462: offset as string instead of float, otherwise it cannot be used as array key in PHP 8.1+.
+ 
 ## 1.5.1 April 5, 2020
  - Fix #370: Extending view fix (effsoft)
  - Fix #306: Add event for failed login (ivan-cc)

--- a/src/User/Helper/TimezoneHelper.php
+++ b/src/User/Helper/TimezoneHelper.php
@@ -36,7 +36,7 @@ class TimezoneHelper
             $timeZones[] = [
                 'timezone' => $timeZone,
                 'name' => "{$timeZone} (UTC " . ($offset > 0 ? '+' : '') . "{$offset})",
-                'offset' => "$offset",
+                'offset' => sprintf("%.3f", $offset),
             ];
         }
 

--- a/src/User/Helper/TimezoneHelper.php
+++ b/src/User/Helper/TimezoneHelper.php
@@ -36,7 +36,7 @@ class TimezoneHelper
             $timeZones[] = [
                 'timezone' => $timeZone,
                 'name' => "{$timeZone} (UTC " . ($offset > 0 ? '+' : '') . "{$offset})",
-                'offset' => $offset,
+                'offset' => "$offset",
             ];
         }
 


### PR DESCRIPTION
Code breaks in PHP 8.1+. Have to make offset as string instead of float, otherwise it cannot be used as array key.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes/no
| Tests pass?   | yes
| Fixed issues  |  Fixed this issue [#461](https://github.com/2amigos/yii2-usuario/issues/461#issue-1317800351)
