### PR TITLE
fix typo to allow filtering on Last login IP field

### DIFF
--- a/src/User/Search/UserSearch.php
+++ b/src/User/Search/UserSearch.php
@@ -66,7 +66,7 @@ class UserSearch extends Model
     public function rules()
     {
         return [
-            'safeFields' => [['username', 'email', 'registration_ip', 'created_at', 'last_login_at, last_login_ip'], 'safe'],
+            'safeFields' => [['username', 'email', 'registration_ip', 'created_at', 'last_login_at', 'last_login_ip'], 'safe'],
             'createdDefault' => [['created_at', 'last_login_at'], 'default', 'value' => null],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | Last login IP field cannot be filtered because of typo
