### PR TITLE
fixed translations not initialized

### DIFF
--- a/src/User/Bootstrap.php
+++ b/src/User/Bootstrap.php
@@ -46,8 +46,8 @@ class Bootstrap implements BootstrapInterface
     {
         if ($app->hasModule('user') && $app->getModule('user') instanceof Module) {
             $map = $this->buildClassMap($app->getModule('user')->classMap);
-            $this->initContainer($app, $map);
             $this->initTranslations($app);
+            $this->initContainer($app, $map);
             $this->initMailServiceConfiguration($app, $app->getModule('user'));
 
             if ($app instanceof WebApplication) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

Latest 2fa by email update includes translations in the initContainer section, but translations are initialized only after initContainer so an exception is thrown. The Translations need to be initialized berofe accessing the translations in initContainer to not throw errors.

https://github.com/2amigos/yii2-usuario/commit/91d110e1e72d7f29b028fc88fac1f4c1be4e6226#diff-0aee3926d3192a0b5d66c0f7b1d9a87da26addf9c0e708a0c0ef91edad039b04R170

