### PR TITLE
implement module viewPath in all views instead of static file reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ look forward and maintain only >=7.4 versions.
 
 There's a change in flash messages handling, please see #391
 
-- Ehn: update welcome and confirmation email ending line (maxxer)
-- Ehn #361: Record and manage user session history (maranqz)
+- Enh: update welcome and confirmation email ending line (maxxer)
+- Enh #361: Record and manage user session history (maranqz)
 - Fix: replace non-working travis build with working github actions build (TonisOrmisson)
 - Fix: user login events not triggered on ajax requests (TonisOrmisson)
 - Enh: Added minimum requirements when a new password is automatically generated (MatteoF96)
@@ -22,14 +22,15 @@ There's a change in flash messages handling, please see #391
 - Enh: Added SK translations (snickom)
 - Fix: allow `password_changed_at` to be saved when reseting password (p4blojf)
 - Fix #430: Moved `EVENT_BEFORE_PROFILE_UPDATE` to correct place (eluhr)
-- Ehn #456: Added filter to allow forcing 2FA for specific user roles (acordeddu)
-- Ehn #412: Allow role names to support UTF-8 chars (4khobta)
-- Ehn #448: Remove deprecated SwiftMailer, use SymfonyMailer instead (TonisOrmisson)
-- Ehn #428: Translations of the placeholders in the login widget (anapaulaxenon)
+- Enh #456: Added filter to allow forcing 2FA for specific user roles (acordeddu)
+- Enh #412: Allow role names to support UTF-8 chars (4khobta)
+- Enh #448: Remove deprecated SwiftMailer, use SymfonyMailer instead (TonisOrmisson)
+- Enh #428: Translations of the placeholders in the login widget (anapaulaxenon)
 - Update PHP-CS-Fixer configuration to new version (maxxer)
 - Fix #391: Always create flash messages, allow `enableFlashMessages` only to dictate display (ajmedway)
-- Ehn #458: Multiple 2FA channels (email, sms) (acordeddu)
+- Enh #458: Multiple 2FA channels (email, sms) (acordeddu)
 - Fix #432: Fix documentation overlap by shortening page names (cgsmith)
+- Enh #472: implement module viewPath in all views instead of static file reference (tonisormisson)
 
 ## 1.5.1 April 5, 2020
 
@@ -60,8 +61,8 @@ There's a change in flash messages handling, please see #391
 - Fix #209: Doc fix. allowAccountDelete default value is false (Dezinger)
 - Fix #211: Migration boolean default value set to FALSE instead 0 (Dezinger)
 - Fix #213: Migration sql syntax fix (Dezinger)
-- Ehn #131: 2FA libraries now optional (maxxer)
-- Ehn #187: Add GDPR features (Eseperio)
+- Enh #131: 2FA libraries now optional (maxxer)
+- Enh #187: Add GDPR features (Eseperio)
 - Enh #184: Add `last-login-ip` capture capability (kartik-v)
 - Enh: Changed `View::render()` calls in views to use absolute paths (ajmedway)
 - Fix #169: Fix bug in ReCaptchaComponent (BuTaMuH)

--- a/src/User/Controller/AbstractAuthItemController.php
+++ b/src/User/Controller/AbstractAuthItemController.php
@@ -74,6 +74,7 @@ abstract class AbstractAuthItemController extends Controller
             [
                 'searchModel' => $searchModel,
                 'dataProvider' => $searchModel->search(Yii::$app->request->get()),
+                'module' => $this->module
             ]
         );
     }
@@ -101,6 +102,7 @@ abstract class AbstractAuthItemController extends Controller
             [
                 'model' => $model,
                 'unassignedItems' => $this->authHelper->getUnassignedItems($model),
+                'module' => $this->module
             ]
         );
     }
@@ -130,6 +132,7 @@ abstract class AbstractAuthItemController extends Controller
             [
                 'model' => $model,
                 'unassignedItems' => $this->authHelper->getUnassignedItems($model),
+                'module' => $this->module
             ]
         );
     }

--- a/src/User/Controller/AdminController.php
+++ b/src/User/Controller/AdminController.php
@@ -128,6 +128,7 @@ class AdminController extends Controller
             [
                 'dataProvider' => $dataProvider,
                 'searchModel' => $searchModel,
+                'module' => $this->module
             ]
         );
     }

--- a/src/User/Controller/AdminController.php
+++ b/src/User/Controller/AdminController.php
@@ -178,7 +178,10 @@ class AdminController extends Controller
             }
         }
 
-        return $this->render('_account', ['user' => $user]);
+        return $this->render('_account', [
+            'user' => $user,
+            'module' => $this->module
+        ]);
     }
 
     public function actionUpdateProfile($id)
@@ -211,6 +214,7 @@ class AdminController extends Controller
             [
                 'user' => $user,
                 'profile' => $profile,
+                'module' => $this->module
             ]
         );
     }
@@ -224,6 +228,7 @@ class AdminController extends Controller
             '_info',
             [
                 'user' => $user,
+                'module' => $this->module
             ]
         );
     }
@@ -238,6 +243,7 @@ class AdminController extends Controller
             [
                 'user' => $user,
                 'params' => Yii::$app->request->post(),
+                'module' => $this->module
             ]
         );
     }
@@ -372,6 +378,7 @@ class AdminController extends Controller
             'searchModel' => $searchModel,
             'dataProvider' => $dataProvider,
             'user' => $user,
+            'module' => $this->module
         ]);
     }
 

--- a/src/User/Controller/RuleController.php
+++ b/src/User/Controller/RuleController.php
@@ -67,6 +67,7 @@ class RuleController extends Controller
             [
                 'searchModel' => $searchModel,
                 'dataProvider' => $dataProvider,
+                'module' => $this->module
             ]
         );
     }
@@ -89,7 +90,8 @@ class RuleController extends Controller
         return $this->render(
             'create',
             [
-                'model' => $model
+                'model' => $model,
+                'module' => $this->module
             ]
         );
     }
@@ -104,7 +106,7 @@ class RuleController extends Controller
             [
                 'previousName' => $name,
                 'name' => $rule->name,
-                'className' => get_class($rule)
+                'className' => get_class($rule),
             ]
         );
 
@@ -123,6 +125,7 @@ class RuleController extends Controller
             'update',
             [
                 'model' => $model,
+                'module' => $this->module
             ]
         );
     }

--- a/src/User/Service/MailService.php
+++ b/src/User/Service/MailService.php
@@ -12,13 +12,16 @@
 namespace Da\User\Service;
 
 use Da\User\Contracts\ServiceInterface;
+use Da\User\Traits\ModuleAwareTrait;
 use Yii;
 use yii\mail\BaseMailer;
 use yii\mail\MailerInterface;
 
 class MailService implements ServiceInterface
 {
-    protected $viewPath = '@Da/User/resources/views/mail';
+    use ModuleAwareTrait;
+
+    protected $viewPath = '';
 
     protected $type;
     protected $from;
@@ -48,6 +51,7 @@ class MailService implements ServiceInterface
         $this->view = $view;
         $this->params = $params;
         $this->mailer = $mailer;
+        $this->viewPath = $this->getModule()->viewPath . '/mail';
         $this->mailer->setViewPath($this->viewPath);
         $this->mailer->getView()->theme = Yii::$app->view->theme;
     }

--- a/src/User/Widget/LoginWidget.php
+++ b/src/User/Widget/LoginWidget.php
@@ -12,17 +12,22 @@
 namespace Da\User\Widget;
 
 use Da\User\Form\LoginForm;
+use Da\User\Traits\ModuleAwareTrait;
 use Yii;
 use yii\base\Widget;
 
+/**
+ * @deprecated this seems to be unused by this module. To be deleted in future!
+ */
 class LoginWidget extends Widget
 {
+    use ModuleAwareTrait;
     public $validate = true;
 
     public function run()
     {
         return $this->render(
-            '@Da/User/resources/views/widgets/login/form',
+            $this->getModule()->$this->viewPath .'/widgets/login/form',
             [
                 'model' => Yii::createObject(LoginForm::class),
             ]

--- a/src/User/resources/views/admin/_account.php
+++ b/src/User/resources/views/admin/_account.php
@@ -14,10 +14,11 @@ use yii\helpers\Html;
 
 /** @var yii\web\View $this */
 /** @var Da\User\Model\User $user */
+/** @var \Da\User\Module $module */
 
 ?>
 
-<?php $this->beginContent('@Da/User/resources/views/admin/update.php', ['user' => $user]) ?>
+<?php $this->beginContent($module->viewPath. '/admin/update.php', ['user' => $user]) ?>
 
 <?php $form = ActiveForm::begin(
     [

--- a/src/User/resources/views/admin/_assignments.php
+++ b/src/User/resources/views/admin/_assignments.php
@@ -14,10 +14,11 @@ use Da\User\Widget\AssignmentsWidget;
 /** @var yii\web\View $this */
 /** @var Da\User\Model\User $user */
 /** @var string[] $params */
+/** @var \Da\User\Module $module */
 
 ?>
 
-<?php $this->beginContent('@Da/User/resources/views/admin/update.php', ['user' => $user]) ?>
+<?php $this->beginContent($module->viewPath. '/admin/update.php', ['user' => $user]) ?>
 
 <?= yii\bootstrap\Alert::widget(
     [

--- a/src/User/resources/views/admin/_info.php
+++ b/src/User/resources/views/admin/_info.php
@@ -11,10 +11,11 @@
 
 /** @var yii\web\View $this */
 /** @var Da\User\Model\User $user */
+/** @var \Da\User\Module $module */
 
 ?>
 
-<?php $this->beginContent('@Da/User/resources/views/admin/update.php', ['user' => $user]) ?>
+<?php $this->beginContent($module->viewPath. '/admin/update.php', ['user' => $user]) ?>
 
 <table class="table">
     <tr>

--- a/src/User/resources/views/admin/_profile.php
+++ b/src/User/resources/views/admin/_profile.php
@@ -16,11 +16,12 @@ use yii\helpers\Html;
  * @var yii\web\View           $this
  * @var \Da\User\Model\User    $user
  * @var \Da\User\Model\Profile $profile
+ * @var \Da\User\Module $module
  */
 
 ?>
 
-<?php $this->beginContent('@Da/User/resources/views/admin/update.php', ['user' => $user]) ?>
+<?php $this->beginContent($module->viewPath. '/admin/update.php', ['user' => $user]) ?>
 
 <?php $form = ActiveForm::begin(
     [

--- a/src/User/resources/views/admin/_session-history.php
+++ b/src/User/resources/views/admin/_session-history.php
@@ -23,10 +23,11 @@ use yii\data\ActiveDataProvider;
  * @var SessionHistorySearch $searchModel
  * @var ActiveDataProvider $dataProvider
  * @var \Da\User\Model\User $user
+ * @var \Da\User\Module $module
  */
 ?>
 
-<?php $this->beginContent('@Da/User/resources/views/admin/update.php', ['user' => $user]) ?>
+<?php $this->beginContent($module->viewPath. '/admin/update.php', ['user' => $user]) ?>
     <div class="row">
         <div class="col-xs-12">
             <?= Html::a(

--- a/src/User/resources/views/admin/index.php
+++ b/src/User/resources/views/admin/index.php
@@ -24,7 +24,6 @@ use yii\widgets\Pjax;
 $this->title = Yii::t('usuario', 'Manage users');
 $this->params['breadcrumbs'][] = $this->title;
 
-$module = Yii::$app->getModule('user');
 ?>
 
 <?php $this->beginContent($module->viewPath . '/shared/admin_layout.php') ?>

--- a/src/User/resources/views/admin/index.php
+++ b/src/User/resources/views/admin/index.php
@@ -27,7 +27,7 @@ $this->params['breadcrumbs'][] = $this->title;
 $module = Yii::$app->getModule('user');
 ?>
 
-<?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
+<?php $this->beginContent($module->viewPath . '/shared/admin_layout.php') ?>
 
 <?php Pjax::begin() ?>
 <div class="table-responsive">

--- a/src/User/resources/views/permission/create.php
+++ b/src/User/resources/views/permission/create.php
@@ -13,6 +13,7 @@
  * @var yii\web\View $this
  * @var Da\User\Model\Permission $model
  * @var string[] $unassignedItems
+ * @var \Da\User\Module $module
  */
 
 $this->title = Yii::t('usuario', 'Create new permission');
@@ -20,7 +21,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
 ?>
 
-<?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
+<?php $this->beginContent($module->viewPath . '/shared/admin_layout.php') ?>
 
 <?= $this->render(
     '/permission/_form',

--- a/src/User/resources/views/permission/index.php
+++ b/src/User/resources/views/permission/index.php
@@ -13,6 +13,7 @@
  * @var \yii\data\ActiveDataProvider $dataProvider
  * @var yii\web\View $this
  * @var \Da\User\Search\PermissionSearch $searchModel
+ * @var \Da\User\Module $module
  */
 use yii\grid\ActionColumn;
 use yii\grid\GridView;
@@ -23,7 +24,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
 ?>
 
-<?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
+<?php $this->beginContent($module->viewPath . '/shared/admin_layout.php') ?>
 <div class="table-responsive">
 <?= GridView::widget(
     [

--- a/src/User/resources/views/permission/update.php
+++ b/src/User/resources/views/permission/update.php
@@ -13,6 +13,7 @@
  * @var yii\web\View $this
  * @var Da\User\Model\Permission $model
  * @var string[] $unassignedItems
+ * @var \Da\User\Module $module
  */
 
 $this->title = Yii::t('usuario', 'Update permission');
@@ -20,7 +21,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
 ?>
 
-<?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
+<?php $this->beginContent($module->viewPath . '/shared/admin_layout.php') ?>
 
 <?= $this->render(
     '/permission/_form',

--- a/src/User/resources/views/role/create.php
+++ b/src/User/resources/views/role/create.php
@@ -13,13 +13,14 @@
  * @var yii\web\View $this
  * @var \Da\User\Model\Role $model
  * @var string[] $unassignedItems
+ * @var \Da\User\Module $module
  */
 $this->title = Yii::t('usuario', 'Create new role');
 $this->params['breadcrumbs'][] = $this->title;
 
 ?>
 
-<?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
+<?php $this->beginContent($module->viewPath . '/shared/admin_layout.php') ?>
 
 <?= $this->render(
     '/role/_form',

--- a/src/User/resources/views/role/index.php
+++ b/src/User/resources/views/role/index.php
@@ -17,6 +17,7 @@ use yii\helpers\Url;
  * @var \yii\data\DataProviderInterface $dataProvider
  * @var \Da\User\Search\RoleSearch $searchModel
  * @var yii\web\View $this
+ * @var \Da\User\Module $module
  */
 
 $this->title = Yii::t('usuario', 'Roles');
@@ -24,7 +25,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
 ?>
 
-<?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
+<?php $this->beginContent($module->viewPath . '/shared/admin_layout.php') ?>
 <div class="table-responsive">
 <?= GridView::widget(
     [

--- a/src/User/resources/views/role/update.php
+++ b/src/User/resources/views/role/update.php
@@ -13,13 +13,14 @@
  * @var yii\web\View $this
  * @var \Da\User\Model\Role $model
  * @var string[] $unassignedItems
+ * @var \Da\User\Module $module
  */
 $this->title = Yii::t('usuario', 'Update role');
 $this->params['breadcrumbs'][] = $this->title;
 
 ?>
 
-<?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
+<?php $this->beginContent($module->viewPath . '/shared/admin_layout.php') ?>
 
 <?= $this->render(
     '/role/_form',

--- a/src/User/resources/views/rule/create.php
+++ b/src/User/resources/views/rule/create.php
@@ -13,13 +13,14 @@
  * @var yii\web\View $this
  * @var \Da\User\Model\Rule $model
  * @var string[] $unassignedItems
+ * @var \Da\User\Module $module
  */
 $this->title = Yii::t('usuario', 'Create new rule');
 $this->params['breadcrumbs'][] = $this->title;
 
 ?>
 
-<?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
+<?php $this->beginContent($module->viewPath . '/shared/admin_layout.php') ?>
 
 <?= $this->render(
     '/rule/_form',

--- a/src/User/resources/views/rule/index.php
+++ b/src/User/resources/views/rule/index.php
@@ -9,6 +9,7 @@ use yii\rbac\Rule;
  * @var \yii\data\ActiveDataProvider $dataProvider
  * @var \Da\User\Search\RuleSearch $searchModel
  * @var yii\web\View $this
+ * @var \Da\User\Module $module
  */
 
 $this->title = Yii::t('usuario', 'Rules');
@@ -16,7 +17,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
 ?>
 
-<?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
+<?php $this->beginContent($module->viewPath . '/shared/admin_layout.php') ?>
 <div class="table-responsive">
 <?= GridView::widget(
     [

--- a/src/User/resources/views/rule/update.php
+++ b/src/User/resources/views/rule/update.php
@@ -13,14 +13,16 @@
  * @var yii\web\View $this
  * @var \Da\User\Model\Rule $model
  * @var string[] $unassignedItems
+ * @var \Da\User\Module $module
  */
+
 $this->title = Yii::t('usuario', 'Update rule');
 $this->params['breadcrumbs'][] = ['label' => Yii::t('usuario', 'Rules'), 'url' => ['index']];
 $this->params['breadcrumbs'][] = $this->title;
 
 ?>
 
-<?php $this->beginContent('@Da/User/resources/views/shared/admin_layout.php') ?>
+<?php $this->beginContent($module->viewPath . '/shared/admin_layout.php') ?>
 
 <?= $this->render(
     '/rule/_form',


### PR DESCRIPTION
Use the viewPath defined in the module configuration in all places instead of statically referring to @Da.. paths. Makes it easier to decouple the views as a separate repo (bs4/5 etc)