### PR TITLE
Fixed prefix for REST APIs

### DIFF
--- a/docs/install/configuration-options.md
+++ b/docs/install/configuration-options.md
@@ -333,7 +333,11 @@ Default value = `yii\filters\auth\QueryParamAuth` class, therefore access tokens
 
 #### adminRestPrefix (type: `string`, default: `user/api/v1`)
 
-Route prefix for REST admin controller.
+Prefix for the pattern part of every rule for REST admin controller.
+
+#### adminRestRoutePrefix (type: `string`, default: `user/api/v1`)
+
+Prefix for the route part of every rule for REST admin controller.
 
 #### adminRestRoutes (type `array`)
 

--- a/src/User/Bootstrap.php
+++ b/src/User/Bootstrap.php
@@ -291,6 +291,7 @@ class Bootstrap implements BootstrapInterface
         $config = [
             'class' => 'yii\web\GroupUrlRule',
             'prefix' => $module->adminRestPrefix,
+            'routePrefix' => $module->adminRestRoutePrefix,
             'rules' => $rules,
         ];
         $rule = Yii::createObject($config);

--- a/src/User/Module.php
+++ b/src/User/Module.php
@@ -260,9 +260,13 @@ class Module extends BaseModule
      */
     public $authenticatorClass = 'yii\filters\auth\QueryParamAuth';
     /**
-     * @var string Route prefix for REST admin controller.
+     * @var string Prefix for the pattern part of every rule for REST admin controller.
      */
     public $adminRestPrefix = 'user/api/v1';
+    /**
+     * @var string Prefix for the route part of every rule for REST admin controller.
+     */
+    public $adminRestRoutePrefix = 'user/api/v1';
     /**
      * @var array Routes for REST admin controller.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

Added `adminRestRoutePrefix` module parameter to customize prefixes of REST admin controller.
