### PR TITLE
Fixed password recovery link in welcome mail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## dev
+
+- Fix: use correct password recovery url in welcome mail and add functionality to plain text version of the mail
+
 ## 1.6.0 January 9, 2023
 
 **WARNING**: this release (long time due) makes a step forward in PHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## dev
 
-- Fix: use correct password recovery url in welcome mail and add functionality to plain text version of the mail
+- Fix: use correct password recovery url in welcome mail and add functionality to plain text version of the mail (@eluhr)
 
 ## 1.6.0 January 9, 2023
 

--- a/src/User/resources/views/mail/text/welcome.php
+++ b/src/User/resources/views/mail/text/welcome.php
@@ -15,6 +15,9 @@
  * @var \Da\User\Module $module
  * @var bool $showPassword
  */
+
+use yii\helpers\Url;
+
 ?>
 <?= Yii::t('usuario', 'Hello') ?>,
 
@@ -22,6 +25,10 @@
 <?php if ($showPassword || $module->generatePasswords): ?>
     <?= Yii::t('usuario', 'We have generated a password for you') ?>:
     <?= $user->password ?>
+<?php endif ?>
+<?php if ($module->allowPasswordRecovery): ?>
+    <?= Yii::t('usuario', 'If you haven\'t received a password, you can reset it at') ?>:
+    <?= Url::to(['/user/recovery/request'], true) ?>
 <?php endif ?>
 
 <?php if ($token !== null): ?>

--- a/src/User/resources/views/mail/welcome.php
+++ b/src/User/resources/views/mail/welcome.php
@@ -30,7 +30,7 @@ use yii\helpers\Url;
         <?= Yii::t('usuario', 'We have generated a password for you') ?>: <strong><?= $user->password ?></strong>
     <?php endif ?>
     <?php if ($module->allowPasswordRecovery): ?>
-        <?= Yii::t('usuario', 'If you haven\'t received a password, you can reset it at') ?>: <strong><?= Html::a(Html::encode(Url::to(['/user/forgot'], true)), Url::to(['/user/forgot'], true)) ?></strong>
+        <?= Yii::t('usuario', 'If you haven\'t received a password, you can reset it at') ?>: <strong><?= Html::a(Html::encode(Url::to(['/user/recovery/request'], true)), Url::to(['/user/recovery/request'], true)) ?></strong>
     <?php endif ?>
 
 </p>


### PR DESCRIPTION
Used pretty url instead of the actual route and adds this feature for the plain text variant of the mail

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  |no
| Breaks BC?    |no
| Tests pass?   | yes
