### PR TITLE
Use correct User model if overwritten in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: use correct password recovery url in welcome mail and add functionality to plain text version of the mail (@eluhr)
 - Fix: correct viewPath error in LoginWidget (niciz)
 - Enh: possibility to call all the api endpoints with either id or username or email (liviuk2)
+- Fix: use configured User model in SecurityController 2FA confirmation (jussiaho)
 
 ## 1.6.0 January 9, 2023
 

--- a/src/User/Controller/SecurityController.php
+++ b/src/User/Controller/SecurityController.php
@@ -221,9 +221,10 @@ class SecurityController extends Controller
             $validators = $module->twoFactorAuthenticationValidators;
             $credentials = Yii::$app->session->get('credentials');
             $login = $credentials['login'];
-            $user = User::findOne(['email' => $login]);
+            $userModel = $this->getClassMap()->get(User::class);
+            $user = $userModel::findOne(['email' => $login]);
             if ($user == null) {
-                $user = User::findOne(['username' => $login]);
+                $user = $userModel::findOne(['username' => $login]);
             }
             $tfType = $user->getAuthTfType();
 


### PR DESCRIPTION
Two factor authentication doesn't work if the User model has been changed in the config from the modules own model class. This fix gets the correct User model from the class map.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
