### PR TITLE
🐛 fix(2FA): Two Factor Authentication - Filter - Blocks even when two…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev
 
+- Fix: Two Factor Authentication - Filter - Blocks even when two factor authentication is enabled
 - Fix: update Dutch (nl) translations (squio)
 - Enh: possibility to limit the depth of the recursion when getting user ids from roles (mp1509)
 

--- a/src/User/Filter/TwoFactorAuthenticationEnforceFilter.php
+++ b/src/User/Filter/TwoFactorAuthenticationEnforceFilter.php
@@ -38,8 +38,10 @@ class TwoFactorAuthenticationEnforceFilter extends ActionFilter
         }
 
         $permissions = $module->twoFactorAuthenticationForcedPermissions;
+
+        $user = Yii::$app->user->identity;
         $itemsByUser = array_keys($this->getAuthManager()->getItemsByUser(Yii::$app->user->identity->id));
-        if (!empty(array_intersect($permissions, $itemsByUser))) {
+        if (!empty(array_intersect($permissions, $itemsByUser)) && !$user->auth_tf_enabled) {
             Yii::$app->session->setFlash('warning', Yii::t('usuario', 'Your role requires 2FA, you won\'t be able to use the application until you enable it'));
             return Yii::$app->response->redirect(['/user/settings/account'])->send();
         }

--- a/src/User/Filter/TwoFactorAuthenticationEnforceFilter.php
+++ b/src/User/Filter/TwoFactorAuthenticationEnforceFilter.php
@@ -40,7 +40,7 @@ class TwoFactorAuthenticationEnforceFilter extends ActionFilter
         $permissions = $module->twoFactorAuthenticationForcedPermissions;
 
         $user = Yii::$app->user->identity;
-        $itemsByUser = array_keys($this->getAuthManager()->getItemsByUser(Yii::$app->user->identity->id));
+        $itemsByUser = array_keys($this->getAuthManager()->getItemsByUser($user->id));
         if (!empty(array_intersect($permissions, $itemsByUser)) && !$user->auth_tf_enabled) {
             Yii::$app->session->setFlash('warning', Yii::t('usuario', 'Your role requires 2FA, you won\'t be able to use the application until you enable it'));
             return Yii::$app->response->redirect(['/user/settings/account'])->send();

--- a/src/User/Service/MailService.php
+++ b/src/User/Service/MailService.php
@@ -83,11 +83,17 @@ class MailService implements ServiceInterface
      */
     public function run()
     {
-        return $this->mailer
+
+        $result =  $this->mailer
             ->compose(['html' => $this->view, 'text' => "text/{$this->view}"], $this->params)
             ->setFrom($this->from)
             ->setTo($this->to)
             ->setSubject($this->subject)
             ->send();
+
+        if (!$result) {
+            Yii::error("Email sending failed to '{$this->to}'.", 'mailer');
+        }
+        return $result;
     }
 }

--- a/src/User/Service/MailService.php
+++ b/src/User/Service/MailService.php
@@ -83,8 +83,7 @@ class MailService implements ServiceInterface
      */
     public function run()
     {
-
-        $result =  $this->mailer
+        $result = $this->mailer
             ->compose(['html' => $this->view, 'text' => "text/{$this->view}"], $this->params)
             ->setFrom($this->from)
             ->setTo($this->to)

--- a/src/User/Validator/TwoFactorEmailValidator.php
+++ b/src/User/Validator/TwoFactorEmailValidator.php
@@ -111,6 +111,6 @@ class TwoFactorEmailValidator extends TwoFactorCodeValidator
     */
     public function generateCode()
     {
-        return $this->make(TwoFactorEmailCodeGeneratorService::class, $this->user)->run();
+        return $this->make(TwoFactorEmailCodeGeneratorService::class, [$this->user])->run();
     }
 }


### PR DESCRIPTION
… factor authentication is enabled

🐛 fix(email): add error logging when email sending fails 🔒 chore(2FA): fix TwoFactorEmailValidator to pass user as an array The TwoFactorAuthenticationEnforceFilter was blocking users even when two factor authentication was enabled. The filter now checks if the user has two factor authentication enabled before blocking them. The MailService now logs an error when email sending fails. The TwoFactorEmailValidator now passes the user as an array to the TwoFactorEmailCodeGeneratorService.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #513, #515 
