### PR TITLE
#513 Fixed bug in TwoFactorEmailValidator::generateCode() preventing …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Enh: possibility to limit the depth of the recursion when getting user ids from roles (mp1509)
 - Fix: UserSearch avoid fields name conflict if joined with other tables (liviuk2)
 - Fix: PasswordExpireService return false when user model attribute "password_changed_at" is already set at null.
+- Fix #513: Two Factor - Email - Bug in TwoFactorEmailValidator::generateCode() preventing 2fa emails to be sent.
 
 ## 1.6.1 March 4th, 2023
 

--- a/src/User/Validator/TwoFactorEmailValidator.php
+++ b/src/User/Validator/TwoFactorEmailValidator.php
@@ -111,6 +111,6 @@ class TwoFactorEmailValidator extends TwoFactorCodeValidator
     */
     public function generateCode()
     {
-        return $this->make(TwoFactorEmailCodeGeneratorService::class, $this->user)->run();
+        return $this->make(TwoFactorEmailCodeGeneratorService::class, [$this->user])->run();
     }
 }


### PR DESCRIPTION
…2fa emails to be sent.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | #513 
