### PR TITLE
Update PasswordExpireService.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix: update Dutch (nl) translations (squio)
 - Enh: possibility to limit the depth of the recursion when getting user ids from roles (mp1509)
 - Fix: UserSearch avoid fields name conflict if joined with other tables (liviuk2)
+- Fix: PasswordExpireService return false when user model attribute "password_changed_at" is already set at null.
 
 ## 1.6.1 March 4th, 2023
 

--- a/src/User/Service/PasswordExpireService.php
+++ b/src/User/Service/PasswordExpireService.php
@@ -25,8 +25,11 @@ class PasswordExpireService implements ServiceInterface
 
     public function run()
     {
-        return $this->model->updateAttributes([
-            'password_changed_at' => null,
-        ]);
+        if ($this->model->password_changed_at !== null) {
+            return $this->model->updateAttributes([
+                'password_changed_at' => null,
+            ]);
+        }
+        return true;
     }
 }

--- a/src/User/Service/PasswordExpireService.php
+++ b/src/User/Service/PasswordExpireService.php
@@ -25,11 +25,9 @@ class PasswordExpireService implements ServiceInterface
 
     public function run()
     {
-        if ($this->model->password_changed_at !== null) {
-            return $this->model->updateAttributes([
-                'password_changed_at' => null,
-            ]);
-        }
+        $this->model->updateAttributes([
+            'password_changed_at' => null,
+        ]);
         return true;
     }
 }


### PR DESCRIPTION
Fix PasswordExpireService return error when user model attribute "password_changed_at" is already set at null.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
