### PR TITLE
Fix Social Network Auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## dev
 
+- Fix: Social Network Auth (eluhr)
+
 ## 1.6.2 Jan 4th, 2024
 
 - Fix: Two Factor Authentication - Filter - Blocks even when two factor authentication is enabled

--- a/docs/install/configuration-options.md
+++ b/docs/install/configuration-options.md
@@ -143,6 +143,15 @@ List of urls that does not require explicit data processing consent to be access
 Setting this attribute allows the registration process. If you set it to `false`, the module won't allow users to
 register by throwing a `NotFoundHttpException` if the `RegistrationController::actionRegister()` is accessed.
 
+#### enableSocialNetworkRegistration (type: `boolean`, default: `true`)
+
+Setting this attribute allows the registration process via social networks. If you set it to `false`, the module won't allow users to
+register.
+
+#### sendWelcomeMailAfterSocialNetworkRegistration (type: `boolean`, default: `true`)
+
+Setting this attribute controls wether a confirmation mail should be send or not.
+
 #### enableEmailConfirmation (type: `boolean`, default: `true`)
 
 If `true`, the module will send an email with a confirmation link that user needs to click through to complete its

--- a/src/User/AuthClient/Facebook.php
+++ b/src/User/AuthClient/Facebook.php
@@ -12,10 +12,14 @@
 namespace Da\User\AuthClient;
 
 use Da\User\Contracts\AuthClientInterface;
+use Da\User\Traits\AuthClientUserIdTrait;
 use yii\authclient\clients\Facebook as BaseFacebook;
 
 class Facebook extends BaseFacebook implements AuthClientInterface
 {
+
+    use AuthClientUserIdTrait;
+    
     /**
      * {@inheritdoc}
      */

--- a/src/User/AuthClient/GitHub.php
+++ b/src/User/AuthClient/GitHub.php
@@ -12,10 +12,12 @@
 namespace Da\User\AuthClient;
 
 use Da\User\Contracts\AuthClientInterface;
+use Da\User\Traits\AuthClientUserIdTrait;
 use yii\authclient\clients\GitHub as BaseGitHub;
 
 class GitHub extends BaseGitHub implements AuthClientInterface
 {
+    use AuthClientUserIdTrait;
     /**
      * {@inheritdoc}
      */

--- a/src/User/AuthClient/Google.php
+++ b/src/User/AuthClient/Google.php
@@ -12,10 +12,12 @@
 namespace Da\User\AuthClient;
 
 use Da\User\Contracts\AuthClientInterface;
+use Da\User\Traits\AuthClientUserIdTrait;
 use yii\authclient\clients\Google as BaseGoogle;
 
 class Google extends BaseGoogle implements AuthClientInterface
 {
+    use AuthClientUserIdTrait;
     /**
      * {@inheritdoc}
      */

--- a/src/User/AuthClient/LinkedIn.php
+++ b/src/User/AuthClient/LinkedIn.php
@@ -12,10 +12,13 @@
 namespace Da\User\AuthClient;
 
 use Da\User\Contracts\AuthClientInterface;
+use Da\User\Traits\AuthClientUserIdTrait;
 use yii\authclient\clients\LinkedIn as BaseLinkedIn;
 
 class LinkedIn extends BaseLinkedIn implements AuthClientInterface
 {
+    use AuthClientUserIdTrait;
+    
     /**
      * {@inheritdoc}
      */

--- a/src/User/AuthClient/Twitter.php
+++ b/src/User/AuthClient/Twitter.php
@@ -12,10 +12,13 @@
 namespace Da\User\AuthClient;
 
 use Da\User\Contracts\AuthClientInterface;
+use Da\User\Traits\AuthClientUserIdTrait;
 use yii\authclient\clients\Twitter as BaseTwitter;
 
 class Twitter extends BaseTwitter implements AuthClientInterface
 {
+    use AuthClientUserIdTrait;
+    
     /**
      * @return string
      */

--- a/src/User/AuthClient/VKontakte.php
+++ b/src/User/AuthClient/VKontakte.php
@@ -12,11 +12,14 @@
 namespace Da\User\AuthClient;
 
 use Da\User\Contracts\AuthClientInterface;
+use Da\User\Traits\AuthClientUserIdTrait;
 use Yii;
 use yii\authclient\clients\VKontakte as BaseVKontakte;
 
 class VKontakte extends BaseVKontakte implements AuthClientInterface
 {
+    use AuthClientUserIdTrait;
+    
     /**
      * {@inheritdoc}
      */

--- a/src/User/AuthClient/Yandex.php
+++ b/src/User/AuthClient/Yandex.php
@@ -12,11 +12,14 @@
 namespace Da\User\AuthClient;
 
 use Da\User\Contracts\AuthClientInterface;
+use Da\User\Traits\AuthClientUserIdTrait;
 use Yii;
 use yii\authclient\clients\Yandex as BaseYandex;
 
 class Yandex extends BaseYandex implements AuthClientInterface
 {
+    use AuthClientUserIdTrait;
+    
     /**
      * {@inheritdoc}
      */

--- a/src/User/Contracts/AuthClientInterface.php
+++ b/src/User/Contracts/AuthClientInterface.php
@@ -14,8 +14,9 @@ namespace Da\User\Contracts;
 use yii\authclient\ClientInterface;
 
 /**
- * @property-read string $email
- * @property-read string $username
+ * @property-read string|null $email
+ * @property-read string|null $userName
+ * @property-read mixed|null $userId
  */
 interface AuthClientInterface extends ClientInterface
 {
@@ -28,4 +29,9 @@ interface AuthClientInterface extends ClientInterface
      * @return string|null username
      */
     public function getUserName();
+
+    /**
+     * @return mixed|null user id
+     */
+    public function getUserId();
 }

--- a/src/User/Module.php
+++ b/src/User/Module.php
@@ -118,6 +118,14 @@ class Module extends BaseModule
      */
     public $enableRegistration = true;
     /**
+     * @var bool whether to allow registration process for social network or not
+     */
+    public $enableSocialNetworkRegistration = true;
+    /**
+     * @var bool whether to send a welcome mail after the registration process for social network
+     */
+    public $sendWelcomeMailAfterSocialNetworkRegistration = true;
+    /**
      * @var bool whether to force email confirmation to
      */
     public $enableEmailConfirmation = true;

--- a/src/User/Service/SocialNetworkAccountConnectService.php
+++ b/src/User/Service/SocialNetworkAccountConnectService.php
@@ -83,7 +83,7 @@ class SocialNetworkAccountConnectService implements ServiceInterface
                 [],
                 [
                     'provider' => $this->client->getId(),
-                    'client_id' => $data['id'],
+                    'client_id' => $this->client->getUserId(),
                     'data' => json_encode($data),
                 ]
             );

--- a/src/User/Service/SocialNetworkAuthenticateService.php
+++ b/src/User/Service/SocialNetworkAuthenticateService.php
@@ -48,7 +48,7 @@ class SocialNetworkAuthenticateService implements ServiceInterface
     public function run()
     {
         $account = $this->socialNetworkAccountQuery->whereClient($this->client)->one();
-        if (!$this->controller->module->enableRegistration && ($account === null || $account->user === null)) {
+        if (!$this->controller->module->enableSocialNetworkRegistration && ($account === null || $account->user === null)) {
             Yii::$app->session->setFlash('danger', Yii::t('usuario', 'Registration on this website is disabled'));
             $this->authAction->setSuccessUrl(Url::to(['/user/security/login']));
 
@@ -97,7 +97,7 @@ class SocialNetworkAuthenticateService implements ServiceInterface
             [],
             [
                 'provider' => $this->client->getId(),
-                'client_id' => $data['id'],
+                'client_id' => $this->client->getUserId(),
                 'data' => json_encode($data),
                 'username' => $this->client->getUserName(),
                 'email' => $this->client->getEmail(),
@@ -106,7 +106,10 @@ class SocialNetworkAuthenticateService implements ServiceInterface
 
         if (($user = $this->getUser($account)) instanceof User) {
             $account->user_id = $user->id;
-            $account->save(false);
+        }
+
+        if (!$account->save(false)) {
+            return null;
         }
 
         return $account;

--- a/src/User/Service/UserCreateService.php
+++ b/src/User/Service/UserCreateService.php
@@ -31,7 +31,7 @@ class UserCreateService implements ServiceInterface
     protected $securityHelper;
     protected $mailService;
 
-    public function __construct(User $model, MailService $mailService, SecurityHelper $securityHelper)
+    public function __construct(User $model, ?MailService $mailService, SecurityHelper $securityHelper)
     {
         $this->model = $model;
         $this->mailService = $mailService;
@@ -70,7 +70,7 @@ class UserCreateService implements ServiceInterface
             }
 
             $model->trigger(UserEvent::EVENT_AFTER_CREATE, $event);
-            if (!$this->sendMail($model)) {
+            if ($this->mailService instanceof MailService && !$this->sendMail($model)) {
                 $error_msg = Yii::t(
                     'usuario',
                     'Error sending welcome message to "{email}". Please try again later.',

--- a/src/User/Traits/AuthClientUserIdTrait.php
+++ b/src/User/Traits/AuthClientUserIdTrait.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Da\User\Traits;
+
+trait AuthClientUserIdTrait
+{
+    /**
+     * @see \Da\User\Contracts\AuthClientInterface::getUserId()
+     */
+    public function getUserId()
+    {
+        return $this->getUserAttributes()['id'] ?? null;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | yes/no -> Update in interface but trait to support backward compatibility
| Tests pass?   | yes
| Fixed issues  | https://github.com/2amigos/yii2-usuario/issues/359, https://github.com/2amigos/yii2-usuario/issues/383

While I was trying to use the social account feature of the module, I noticed that the feature is not implemented properly in some places or does not work at all in some scenarios. 

- When attempting to log in for the first time via an unconnected network account, the user model is not saved in the database.
- The SocialNetworkServices require an "id" field in the received data packet. More flexibility is provided by adapting the interface and providing a trait for backwards compatibility.
- New property that allows login exclusively via social networks, regardless of the value of the "enableRegistration" property.
- New property that allows you to prevent the sending of a "welcome message" when the user registers via a social network.

This PR solves these problems and at the same time provides a little more flexibility in use.
