### PR TITLE
Added Keycloak as a new Auth Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev
 
+- Enh: Keycloak auth client (e.luhr)
 - Fix: Social Network Auth (eluhr)
 
 ## 1.6.2 Jan 4th, 2024

--- a/docs/guides/social-network-authentication.md
+++ b/docs/guides/social-network-authentication.md
@@ -46,6 +46,7 @@ The following is the list of clients supported by the module:
 - **Facebook** - `Da\User\AuthClient\Facebook`
 - **Github** - `Da\User\AuthClient\Github`
 - **Google** - `Da\User\AuthClient\Google`
+- **Keycloak** - `Da\User\AuthClient\Keycloak`
 - **LinkedIn** - `Da\User\AuthClient\LinkedIn`
 - **Twitter** - `Da\User\AuthClient\Twitter`
 - **VKontakte** - `Da\User\AuthClient\VKontakte`

--- a/src/User/AuthClient/Keycloak.php
+++ b/src/User/AuthClient/Keycloak.php
@@ -13,7 +13,7 @@ use yii\authclient\OpenIdConnect;
  *     'authClientCollection' => [
  *         'class' => 'yii\authclient\Collection',
  *         'clients' => [
- *             'github' => [
+ *             'keycloak' => [
  *                 'class' => 'yii\authclient\clients\Keycloak',
  *                 'clientId' => 'keycloak_client_id',
  *                 'clientSecret' => 'keycloak_client_secret',

--- a/src/User/AuthClient/Keycloak.php
+++ b/src/User/AuthClient/Keycloak.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Da\User\AuthClient;
+
+use Da\User\Contracts\AuthClientInterface;
+use yii\authclient\OpenIdConnect;
+
+class Keycloak extends OpenIdConnect implements AuthClientInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getEmail()
+    {
+        // claim from email scope
+        return $this->getUserAttributes()['email'] ?? null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUserName()
+    {
+        // claim from profile scope
+        return $this->getUserAttributes()['preferred_username'] ?? $this->getEmail();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUserId()
+    {
+        return $this->getUserAttributes()['sub'] ?? null;
+    }
+}

--- a/src/User/AuthClient/Keycloak.php
+++ b/src/User/AuthClient/Keycloak.php
@@ -5,6 +5,26 @@ namespace Da\User\AuthClient;
 use Da\User\Contracts\AuthClientInterface;
 use yii\authclient\OpenIdConnect;
 
+/**
+ * Example application configuration:
+ *
+ * ```php
+ * 'components' => [
+ *     'authClientCollection' => [
+ *         'class' => 'yii\authclient\Collection',
+ *         'clients' => [
+ *             'github' => [
+ *                 'class' => 'yii\authclient\clients\Keycloak',
+ *                 'clientId' => 'keycloak_client_id',
+ *                 'clientSecret' => 'keycloak_client_secret',
+ *                 'issuerUrl' => 'http://keycloak/realms/your-realm',
+ *             ],
+ *         ],
+ *     ]
+ *     // ...
+ * ]
+ * ```
+*/
 class Keycloak extends OpenIdConnect implements AuthClientInterface
 {
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

With this pull request I have added a new Auth Client for Keycloak. Here is an example of how it can be configured:

```php
// ... 
'components' => [
    // ...
    'authClientCollection' => [
        'class' => 'yii\authclient\Collection',
        'clients' => [
            'facebook' => [
                'class' => 'Da\User\AuthClient\Keycloak',
                'clientId' => 'keycloak_client_id',
                'clientSecret' => 'keycloak_client_secret',
                'issuerUrl' => 'http://keycloak/realms/your-realm'
            ]
        ]
    ]
]
```