### PR TITLE
Allow/suggest new v3 releases of 2amigos 2fa dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enh: Keycloak auth client (e.luhr)
 - Fix: Social Network Auth (eluhr)
+- Enh: Allow/suggest new v3 releases of 2amigos 2fa dependencies: 2fa-library, qrcode-library (TonisOrmisson) 
 
 ## 1.6.2 Jan 4th, 2024
 

--- a/composer.json
+++ b/composer.json
@@ -49,13 +49,13 @@
     },
     "suggest": {
         "yiisoft/yii2-symfonymailer": "A mailer driver is needed to send e-mails. Older versions use abandoned Swiftmailer which can be replaced with symfonymailer",
-        "2amigos/2fa-library": "Needed if you want to enable 2 Factor Authentication. Require version ^1.0",
-        "2amigos/qrcode-library": "Needed if you want to enable 2FA with QR Code generation. Require version ^1.1"
+        "2amigos/2fa-library": "Needed if you want to enable 2 Factor Authentication. Require version ^2 or ^3",
+        "2amigos/qrcode-library": "Needed if you want to enable 2FA with QR Code generation. Require version ^2 or ^3"
     },
     "require-dev": {
         "php": ">=7.4",
-        "2amigos/2fa-library": "^2.0",
-        "2amigos/qrcode-library": "^2.0",
+        "2amigos/2fa-library": "^2.0|^3.0",
+        "2amigos/qrcode-library": "^2.0|^3.0",
         "friendsofphp/php-cs-fixer": "^3",
         "yiisoft/yii2-symfonymailer": "^2|^3",
         "squizlabs/php_codesniffer": "*",


### PR DESCRIPTION
2amigos has recently released v3 of their 2fa-library & qrcode-library. Tested them to work ok. Updated the require-dev & suggest to use v2 or v3 of them
