### PR TITLE
Add option to limit profile views only for admin users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix: Social Network Auth (eluhr)
 - Enh #532: /user/registration/register now shows form validation errors
 - Enh: Allow/suggest new v3 releases of 2amigos 2fa dependencies: 2fa-library, qrcode-library (TonisOrmisson) 
+- Enh: Added option to disable viewing any other user's profile for non-admin users (TonisOrmisson)
 
 ## 1.6.2 Jan 4th, 2024
 

--- a/docs/install/configuration-options.md
+++ b/docs/install/configuration-options.md
@@ -313,6 +313,11 @@ Set to `true` to restrict user assignments to roles only.
 
 If `true` registration and last login IPs are not logged into users table, instead a dummy 127.0.0.1 is used
 
+
+#### disableProfileViewsForRegularUsers (type: `boolean`, default: `false`)
+
+If `true` only admin users have access to view any other user's profile. By default any user can see any other users public profile page.
+
 #### minPasswordRequirements (type: `array`, default: `['lower' => 1, 'digit' => 1, 'upper' => 1]`)
 
 Minimum requirements when a new password is automatically generated.

--- a/src/User/Controller/ProfileController.php
+++ b/src/User/Controller/ProfileController.php
@@ -11,15 +11,20 @@
 
 namespace Da\User\Controller;
 
+use Da\User\Model\User;
 use Da\User\Query\ProfileQuery;
+use Da\User\Traits\ModuleAwareTrait;
 use Yii;
 use yii\base\Module;
 use yii\filters\AccessControl;
 use yii\web\Controller;
+use yii\web\ForbiddenHttpException;
 use yii\web\NotFoundHttpException;
 
 class ProfileController extends Controller
 {
+    use ModuleAwareTrait;
+
     protected $profileQuery;
 
     /**
@@ -67,6 +72,13 @@ class ProfileController extends Controller
 
     public function actionShow($id)
     {
+        $user = Yii::$app->user;
+        /** @var User $identity */
+        $identity = $user->getIdentity();
+        if($user->getId() != $id && $this->module->disableProfileViewsForRegularUsers && !$identity->getIsAdmin()) {
+            throw new ForbiddenHttpException();
+        }
+
         $profile = $this->profileQuery->whereUserId($id)->one();
 
         if ($profile === null) {

--- a/src/User/Module.php
+++ b/src/User/Module.php
@@ -242,6 +242,10 @@ class Module extends BaseModule
      */
     public $disableIpLogging = false;
     /**
+     * @var boolean whether to disable viewing any user's profile for non-admin users
+     */
+    public $disableProfileViewsForRegularUsers = false;
+    /**
      * @var array Minimum requirements when a new password is automatically generated.
      *            Array structure: `requirement => minimum number characters`.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

Currently any user can check any other users profile. This change will add a module parameter `disableProfileViewsForRegularUsers` which will only allow admin level users to check other people's profiles.
