### PR TITLE
Use recaptcha.net instead of google.com (EU Cookies law)

### DIFF
--- a/src/User/Widget/ReCaptchaWidget.php
+++ b/src/User/Widget/ReCaptchaWidget.php
@@ -113,7 +113,7 @@ class ReCaptchaWidget extends InputWidget
         $view = $this->getView();
 
         $view->registerJsFile(
-            '//www.google.com/recaptcha/api.js?hl=' . $this->getLanguageCode(),
+            '//www.recaptcha.net/recaptcha/api.js?hl=' . $this->getLanguageCode(),
             [
                 'position' => View::POS_HEAD,
                 'async' => true,


### PR DESCRIPTION
In current implementation, ReCaptcha is configured to use the `google.com` domain. While this setup is functional, it introduces potential legal and compliance risks related to cookie management. Specifically, the `google.com` domain can set additional cookies that may not be directly related to our website's functionality. These extra cookies raise concerns regarding user privacy and the stringent requirements of various cookie laws, such as the EU's GDPR.

Under these regulations, websites must obtain explicit consent from users before any non-essential cookies are stored or accessed on their device. The presence of third-party cookies from `google.com`, without clear and informed consent, could place us at risk of non-compliance.

To mitigate these risks, I propose we switch the ReCaptcha service to use the `recaptcha.net` domain instead. This alternative domain offers the same functionality but with fewer implications regarding cookie placement. Using `recaptcha.net` minimizes the likelihood of inadvertently violating cookie regulations, as it's less likely to introduce unrelated or non-essential cookies. This change will help ensure our compliance with cookie laws while maintaining the integrity and security provided by ReCaptcha.

I've prepared the necessary code changes for this switch and tested them to confirm that ReCaptcha continues to work as expected without any loss in functionality. This update will make our site more privacy-friendly and legally compliant.

Looking forward to your feedback and approval.


| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
