### PR TITLE
Improve exception thrown when user does not exists

### DIFF
--- a/src/User/Service/PasswordRecoveryService.php
+++ b/src/User/Service/PasswordRecoveryService.php
@@ -19,6 +19,7 @@ use Da\User\Traits\MailAwareTrait;
 use Da\User\Traits\ModuleAwareTrait;
 use Exception;
 use Yii;
+use yii\web\NotFoundHttpException;
 
 class PasswordRecoveryService implements ServiceInterface
 {
@@ -50,7 +51,7 @@ class PasswordRecoveryService implements ServiceInterface
             $user = $this->query->whereEmail($this->email)->one();
 
             if ($user === null) {
-                throw new \RuntimeException('User not found.');
+                throw new NotFoundHttpException(Yii::t('usuario', 'User not found'));
             }
 
             $token = TokenFactory::makeRecoveryToken($user->id);


### PR DESCRIPTION
User not found is not a RuntimeException. It must be a NotFoundException

See 

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #551
