### PR TITLE
V2: fixed reset form not centered in bs5 in some occasions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -76,7 +76,7 @@ jobs:
               run:  vendor/bin/phpstan analyse
 
             - name: Archive failed tests artifacts - test output & log
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               if: failure()
               with:
                   name: test-outputs-php-${{ matrix.php-versions }}

--- a/src/User/resources/views/bootstrap5/recovery/reset.php
+++ b/src/User/resources/views/bootstrap5/recovery/reset.php
@@ -22,7 +22,8 @@ $this->title = Yii::t('usuario', 'Reset your password');
 $this->params['breadcrumbs'][] = $this->title;
 ?>
 <div class="row">
-    <div class="col-md-4 col-md-offset-4 col-sm-6 col-sm-offset-3">
+    <div class="col"></div>
+    <div class="col-xs-8 col-sm-7 col-md-6 col-lg-5 col-xl-4 ">
         <div class="card">
             <div class="card-header">
                 <h3 class="m-0"><?= Html::encode($this->title) ?></h3>
@@ -44,4 +45,5 @@ $this->params['breadcrumbs'][] = $this->title;
             </div>
         </div>
     </div>
+    <div class="col"></div>
 </div>


### PR DESCRIPTION
fixed reset form not centered in bs5 in some occasions. The layout changed to the same as other similar views.