### PR TITLE
v2: fixed pretty-urls not working from console apps

### DIFF
--- a/src/User/Bootstrap.php
+++ b/src/User/Bootstrap.php
@@ -32,6 +32,7 @@ use yii\console\Application as ConsoleApplication;
 use yii\helpers\ArrayHelper;
 use yii\i18n\PhpMessageSource;
 use yii\web\Application as WebApplication;
+use yii\web\UrlManager;
 
 /**
  * Bootstrap class of the yii2-usuario extension. Configures container services, initializes translations,
@@ -53,10 +54,10 @@ class Bootstrap implements BootstrapInterface
             $this->initTranslations($app);
             $this->initContainer($app, $map);
             $this->initMailServiceConfiguration($app, $app->getModule('user'));
+            $this->initUrlRoutes($app);
 
             if ($app instanceof WebApplication) {
                 $this->initControllerNamespace($app);
-                $this->initUrlRoutes($app);
                 $this->initUrlRestRoutes($app);
                 $this->initAuthCollection($app);
                 $this->initAuthManager($app);
@@ -264,11 +265,11 @@ class Bootstrap implements BootstrapInterface
     /**
      * Initializes web url routes (rules in Yii2).
      *
-     * @param WebApplication $app
+     * @param Application $app
      *
      * @throws InvalidConfigException
      */
-    protected function initUrlRoutes(WebApplication $app)
+    protected function initUrlRoutes(Application $app)
     {
         $module = $this->getModule();
         $config = [
@@ -281,8 +282,13 @@ class Bootstrap implements BootstrapInterface
             $config['routePrefix'] = 'user';
         }
 
+        $urlManager = $app->getUrlManager();
+        if(!($urlManager instanceof UrlManager)) {
+            return;
+        }
+
         $rule = Yii::createObject($config);
-        $app->getUrlManager()->addRules([$rule], false);
+        $urlManager->addRules([$rule], false);
     }
 
     /**


### PR DESCRIPTION
The `Module->routes` do not get initialized for console-applications. This results in any extended applications not getting pretty urls (defined via  `Module->routes` ) via console. 