### PR TITLE
Fixed php 8.4 issues Implicitly marking parameter $token as nullable is deprecated

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -26,7 +26,7 @@ jobs:
                     MYSQL_PASSWORD: password
                     MYSQL_DATABASE: yii2-usuario-test
                     MYSQL_ROOT_PASSWORD: password
-                options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+                options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=5s --health-retries=3
 
         steps:
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,11 +14,11 @@ jobs:
             fail-fast: false
             matrix:
                 operating-system: ['ubuntu-latest']
-                php-versions: ['8.1', '8.0','7.4']
+                php-versions: ['8.4','8.3','8.2','8.1', '8.0','7.4']
 
         services:
             mariadb:
-                image: mariadb:10
+                image: mariadb:lts
                 ports:
                     - 3306:3306
                 env:
@@ -38,7 +38,7 @@ jobs:
                   ini-values: post_max_size=256M, max_execution_time=180
                   coverage: xdebug
 
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
 
             - name: Verify MariaDB connection
@@ -52,7 +52,7 @@ jobs:
 
             - name: Cache Composer packages
               id: composer-cache
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: vendor
                   key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/src/User/Event/ResetPasswordEvent.php
+++ b/src/User/Event/ResetPasswordEvent.php
@@ -29,7 +29,7 @@ final class ResetPasswordEvent extends Event
     protected $form;
     protected $token;
 
-    public function __construct(Token $token = null, RecoveryForm $form = null, array $config = [])
+    public function __construct(?Token $token = null, ?RecoveryForm $form = null, array $config = [])
     {
         $this->form = $form;
         $this->token = $token;

--- a/src/User/Factory/MailFactory.php
+++ b/src/User/Factory/MailFactory.php
@@ -52,7 +52,7 @@ class MailFactory
      * @throws InvalidConfigException
      * @return MailService
      */
-    public static function makeRecoveryMailerService($email, Token $token = null)
+    public static function makeRecoveryMailerService($email, ?Token $token = null)
     {
         /** @var Module $module */
         $module = Yii::$app->getModule('user');
@@ -74,7 +74,7 @@ class MailFactory
      * @throws InvalidConfigException
      * @return MailService
      */
-    public static function makeConfirmationMailerService(User $user, Token $token = null)
+    public static function makeConfirmationMailerService(User $user, ?Token $token = null)
     {
         /** @var Module $module */
         $module = Yii::$app->getModule('user');

--- a/src/User/Model/Profile.php
+++ b/src/User/Model/Profile.php
@@ -144,7 +144,7 @@ class Profile extends ActiveRecord
      *
      * @return DateTime
      */
-    public function getLocalTimeZone(DateTime $dateTime = null)
+    public function getLocalTimeZone(?DateTime $dateTime = null)
     {
         return $dateTime === null ? new DateTime() : $dateTime->setTimezone($this->getTimeZone());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

Also, the actions pipeline is updated to new versions, the old ones did not run any more. 
