### PR TITLE
568 SettingsController::actionGdprDelete() can now GDPR delete Users …

### DIFF
--- a/src/User/Controller/SettingsController.php
+++ b/src/User/Controller/SettingsController.php
@@ -225,7 +225,6 @@ class SettingsController extends Controller
             $this->trigger(GdprEvent::EVENT_BEFORE_DELETE, $event);
 
             if ($event->isValid) {
-                Yii::$app->user->logout();
                 //Disconnect social networks
                 $networks = $this->socialNetworkAccountQuery->where(['user_id' => $user->id])->all();
                 foreach ($networks as $network) {
@@ -255,6 +254,9 @@ class SettingsController extends Controller
                     'bio' => Yii::t('usuario', 'Deleted by GDPR request')
                     ]
                 );
+
+                //Now User has been GDPRred, log it out
+                Yii::$app->user->logout();
             }
             $this->trigger(GdprEvent::EVENT_AFTER_DELETE, $event);
 

--- a/src/User/Query/SocialNetworkAccountQuery.php
+++ b/src/User/Query/SocialNetworkAccountQuery.php
@@ -18,6 +18,18 @@ class SocialNetworkAccountQuery extends ActiveQuery
 {
     public function whereId($id)
     {
+        // If $this already contains a condition for 'id', remove it
+        // to avoid multiple ANDed 'id' conditions.
+        // @ref https://github.com/2amigos/yii2-usuario/issues/568
+        if (is_array($this->where)) {
+            foreach ($this->where as $idx => $arrCondition) {
+                if (isset($arrCondition['id'])) {
+                    array_splice($this->where, $idx, 1);
+                    break;
+                }
+            }
+        }
+
         return $this->andWhere(['id' => $id]);
     }
 


### PR DESCRIPTION
…that have more than one social network records.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  |no
| Breaks BC?    |no
| Tests pass?   | yes
| Fixed issues  | #568 
